### PR TITLE
Add cmake option to enable network adapter (dev9) support

### DIFF
--- a/cmake/SelectPcsx2Plugins.cmake
+++ b/cmake/SelectPcsx2Plugins.cmake
@@ -85,19 +85,21 @@ endif()
 #---------------------------------------
 #			dev9null
 #---------------------------------------
-if(GTKn_FOUND OR LIBRETRO)
+if((GTKn_FOUND OR LIBRETRO) AND NOT ENABLE_DEV9GHZDRK)
     set(dev9null TRUE)
 endif()
 
 #---------------------------------------
 #			dev9ghzdrk
 #---------------------------------------
-if(NOT DISABLE_DEV9GHZDRK AND NOT LIBRETRO)
-if(GTKn_FOUND AND PCAP_FOUND AND LIBXML2_FOUND)
+if(NOT DISABLE_DEV9GHZDRK AND ENABLE_DEV9GHZDRK)
+if((GTKn_FOUND OR LIBRETRO) AND PCAP_FOUND AND LIBXML2_FOUND)
     set(dev9ghzdrk TRUE)
     list(APPEND CMAKE_MODULE_PATH
         ${CMAKE_MODULE_PATH}/macros)
+if(NOT LIBRETRO)
     include(GlibCompileResourcesSupport) 
+endif()
 else()
     set(dev9ghzdrk FALSE)
     print_dep("Skip build of dev9ghzdrk: missing dependencies" "${msg_dep_dev}")

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -923,7 +923,11 @@ if(BUILTIN_USB)
     set(pcsx2FinalLibs ${pcsx2FinalLibs} USBnull-0.7.0)
 endif()
 if(BUILTIN_DEV9)
+  if(ENABLE_DEV9GHZDRK)
+    set(pcsx2FinalLibs ${pcsx2FinalLibs} dev9ghzdrk-0.4)
+  else()
     set(pcsx2FinalLibs ${pcsx2FinalLibs} dev9null-0.5.0)
+  endif()
 endif()
 
 # additonal include directories

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -10,7 +10,7 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/plugins/dev9null" AND dev9null)
 	add_subdirectory(dev9null)
 endif()
 
-if(EXISTS "${CMAKE_SOURCE_DIR}/plugins/dev9ghzdrk" AND dev9ghzdrk AND NOT LIBRETRO)
+if(EXISTS "${CMAKE_SOURCE_DIR}/plugins/dev9ghzdrk" AND dev9ghzdrk)
 	add_subdirectory(dev9ghzdrk)
 endif()
 

--- a/plugins/dev9ghzdrk/CMakeLists.txt
+++ b/plugins/dev9ghzdrk/CMakeLists.txt
@@ -57,6 +57,7 @@ set(dev9ghzdrkSources
 set(dev9ghzdrkHeaders
 )
 
+if(NOT LIBRETRO)
 compile_gresources( dev9ghzdrkUI_C 
                    dev9ghzdrkUI_XML 
                    TYPE EMBED_C
@@ -74,6 +75,7 @@ compile_gresources( dev9ghzdrkUI_H
                    COMPRESS_ALL
                    STRIPBLANKS_ALL
 )
+endif()
 
 # dev9ghzdrk Linux sources
 set(dev9ghzdrkLinuxSources

--- a/plugins/dev9ghzdrk/DEV9.cpp
+++ b/plugins/dev9ghzdrk/DEV9.cpp
@@ -88,7 +88,9 @@ const unsigned char revision = 0;
 const unsigned char build    = 4;    // increase that with each version
 
 
+#ifndef BUILTIN_DEV9_PLUGIN
 static const char *libraryName     = "GiGaHeRz's DEV9 Driver"
+#endif
 #ifdef _DEBUG
 	"(debug)"
 #endif
@@ -102,6 +104,7 @@ int hEeprom;
 int mapping;
 #endif
 
+#ifndef BUILTIN_DEV9_PLUGIN
 EXPORT_C_(u32)
 PS2EgetLibType() {
 	return PS2E_LT_DEV9;
@@ -116,10 +119,13 @@ EXPORT_C_(u32)
 PS2EgetLibVersion2(u32 type) {
 	return (version<<16) | (revision<<8) | build;
 }
+#endif
 
 
+#ifndef __LIBRETRO__
 std::string s_strIniPath = "inis";
 std::string s_strLogPath = "logs";
+#endif
 // Warning: The below log function is SLOW. Better fix it before attempting to use it.
 #ifdef _DEBUG
 int Log = 1;
@@ -256,6 +262,9 @@ DEV9open(void *pDsp)
 {
 	DEV9_LOG("DEV9open\n");
 	LoadConf();
+#ifdef __LIBRETRO__
+  SaveConf();
+#endif
 	DEV9_LOG("open r+: %s\n", config.Hdd);
 	config.HddSize = 8*1024;
 	
@@ -736,6 +745,35 @@ DEV9setLogDir(const char* dir)
 	// Currently dosn't change winPcap log directories post DEV9open()
 	DEV9Log.Close();
 	DEV9LogInit();
+}
+
+EXPORT_C_(void)
+DEV9about()
+{
+}
+
+EXPORT_C_(s32)
+DEV9freeze(int mode, freezeData *data)
+{
+    // This should store or retrieve any information, for if emulation
+    // gets suspended, or for savestates.
+    switch (mode) {
+        case FREEZE_LOAD:
+            // Load previously saved data.
+            break;
+        case FREEZE_SAVE:
+            // Save data.
+            break;
+        case FREEZE_SIZE:
+            // return the size of the data.
+            break;
+    }
+    return 0;
+}
+
+EXPORT_C_(void)
+DEV9keyEvent(keyEvent *ev)
+{
 }
 
 int emu_printf(const char *fmt, ...)

--- a/plugins/dev9ghzdrk/Linux/Linux.cpp
+++ b/plugins/dev9ghzdrk/Linux/Linux.cpp
@@ -15,7 +15,9 @@
 
 #include <stdio.h>
 
+#ifndef __LIBRETRO__
 #include <gtk/gtk.h>
+#endif
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -28,7 +30,9 @@
 #include "pcap_io.h"
 #include "net.h"
 
+#ifndef __LIBRETRO__
 static GtkBuilder * builder;
+#endif
 
 void SysMessage(char *fmt, ...) {
     va_list list;
@@ -38,6 +42,7 @@ void SysMessage(char *fmt, ...) {
     vsprintf(tmp,fmt,list);
     va_end(list);
 
+#ifndef __LIBRETRO__
     GtkWidget *dialog = gtk_message_dialog_new (NULL,
                         GTK_DIALOG_MODAL,
                         GTK_MESSAGE_ERROR,
@@ -45,11 +50,14 @@ void SysMessage(char *fmt, ...) {
                         "%s", tmp);
     gtk_dialog_run (GTK_DIALOG (dialog));
     gtk_widget_hide(dialog);
+#endif
 }
 
 void OnInitDialog() {
+#ifndef __LIBRETRO__
     char *dev;
     gint idx = 0;
+#endif
     static int initialized = 0;
 
     LoadConf();
@@ -57,6 +65,7 @@ void OnInitDialog() {
     if( initialized )
         return;
 
+#ifndef __LIBRETRO__
     gtk_combo_box_text_append_text((GtkComboBoxText *)gtk_builder_get_object(builder,"IDC_BAYTYPE"),"Expansion");
     gtk_combo_box_text_append_text((GtkComboBoxText *)gtk_builder_get_object(builder,"IDC_BAYTYPE"),"PC Card");
     for (int i=0; i<pcap_io_get_dev_num(); i++) {
@@ -72,12 +81,14 @@ void OnInitDialog() {
                   config.ethEnable);
     gtk_toggle_button_set_active ((GtkToggleButton *)gtk_builder_get_object(builder,"IDC_HDDENABLED"),
                   config.hddEnable);
+#endif
 
     initialized = 1;
 }
 
 void OnOk() {
 
+#ifndef __LIBRETRO__
     char* ptr = gtk_combo_box_text_get_active_text((GtkComboBoxText *)gtk_builder_get_object(builder,"IDC_ETHDEV"));
     strcpy(config.Eth, ptr);
 
@@ -85,12 +96,14 @@ void OnOk() {
 
     config.ethEnable = gtk_toggle_button_get_active ((GtkToggleButton *)gtk_builder_get_object(builder,"IDC_ETHENABLED"));
     config.hddEnable = gtk_toggle_button_get_active ((GtkToggleButton *)gtk_builder_get_object(builder,"IDC_HDDENABLED"));
+#endif
 
     SaveConf();
 
 }
 
 /* Simple GTK+2 variant of gtk_builder_add_from_resource() */
+#ifndef __LIBRETRO__
 static guint builder_add_from_resource(GtkBuilder *builder
     , const gchar *resource_path
     , GError **error)
@@ -117,10 +130,15 @@ static guint builder_add_from_resource(GtkBuilder *builder
 
     return ret;
 }
+#endif
 
 EXPORT_C_(void)
 DEV9configure() {
 
+#ifdef __LIBRETRO__
+  LoadConf();
+  SaveConf();
+#else
     gtk_init (NULL, NULL);
     GError *error = NULL;
     builder = gtk_builder_new();
@@ -140,6 +158,7 @@ DEV9configure() {
     break;
     }
     gtk_widget_hide (GTK_WIDGET(dlg));
+#endif
 
 }
 

--- a/plugins/dev9ghzdrk/pcap_io.cpp
+++ b/plugins/dev9ghzdrk/pcap_io.cpp
@@ -23,6 +23,7 @@
 #elif defined(__linux__)
 #include <sys/ioctl.h>
 #include <net/if.h>
+#include <unistd.h>
 #endif
 #include <stdio.h>
 #include <stdarg.h>


### PR DESCRIPTION
Although upstream is in the process of merging the dev9 plugin into pcsx2 core, we can still enable this as a plugin on libretro's current version separately.