### PR TITLE
Add 'Enable Widescreen Patches' option

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -57,15 +57,15 @@ struct retro_core_option_definition option_defs[] = {
 	},
 	"1"},
 
-	{"pcsx2_force_widescreen",
-	"Force Widescreen",
+	{"pcsx2_aspect_ratio",
+	"Aspect Ratio",
 	"Content restart required",
 	{
-		{"disabled", NULL},
-		{"enabled", NULL},
+		{"0", "Standard (4:3)"},
+		{"1", "Widescreen (16:9)"},
 		{NULL, NULL},
 	},
-	"disabled"},
+	"0"},
 
 	{"pcsx2_anisotropic_filter",
 	 "Anisotropic Filtering",

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -59,13 +59,23 @@ struct retro_core_option_definition option_defs[] = {
 
 	{"pcsx2_aspect_ratio",
 	"Aspect Ratio",
-	"Content restart required",
+	"Sets the aspect ratio. Setting the aspect ratio to Widescreen (16:9) stretches the display. For proper widescreen in select games, also turn on the 'Enable Widescreen Patches' option. (Content restart required)",
 	{
 		{"0", "Standard (4:3)"},
 		{"1", "Widescreen (16:9)"},
 		{NULL, NULL},
 	},
 	"0"},
+
+	{"pcsx2_enable_widescreen_patches",
+	"Enable Widescreen Patches",
+	"Enables widescreen patches that allow certain games to render in true 16:9 ratio without stretching the display. For the widescreen patches to display properly, the 'Aspect Ratio' option should be set to Widescreen (16:9). (Content restart required)",
+	{
+		{"disabled", NULL},
+		{"enabled", NULL},
+		{NULL, NULL},
+	},
+	"disabled"},
 
 	{"pcsx2_anisotropic_filter",
 	 "Anisotropic Filtering",

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -329,6 +329,7 @@ void retro_init(void)
 	g_Conf->BaseFilenames.Plugins[PluginId_DEV9] = "Built-in";
 	g_Conf->EmuOptions.EnableIPC = false;
 
+	g_Conf->EmuOptions.EnableWideScreenPatches = option_value(BOOL_PCSX2_OPT_ENABLE_WIDESCREEN_PATCHES, KeyOptionBool::return_type);
 	g_Conf->EmuOptions.GS.FrameSkipEnable = option_value(BOOL_PCSX2_OPT_FRAMESKIP, KeyOptionBool::return_type);
 	g_Conf->EmuOptions.GS.FramesToDraw = option_value(INT_PCSX2_OPT_FRAMES_TO_DRAW, KeyOptionInt::return_type);
 	g_Conf->EmuOptions.GS.FramesToSkip = option_value(INT_PCSX2_OPT_FRAMES_TO_SKIP, KeyOptionInt::return_type);

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -393,7 +393,7 @@ void retro_get_system_av_info(retro_system_av_info* info)
 	info->geometry.max_width = info->geometry.base_width;
 	info->geometry.max_height = info->geometry.base_height;
 
-	if (! option_value(BOOL_PCSX2_OPT_FORCE_WIDESCREEN, KeyOptionBool::return_type))
+	if (option_value(INT_PCSX2_OPT_ASPECT_RATIO, KeyOptionInt::return_type) == 0)
 		info->geometry.aspect_ratio = 4.0f / 3.0f;
 	else
 		info->geometry.aspect_ratio = 16.0f / 9.0f;

--- a/libretro/options_tools.h
+++ b/libretro/options_tools.h
@@ -15,7 +15,6 @@ extern retro_log_printf_t log_cb;
 extern void GSUpdateOptions();
 
 static const char* BOOL_PCSX2_OPT_FASTBOOT = "pcsx2_fastboot";
-static const char* BOOL_PCSX2_OPT_FORCE_WIDESCREEN = "pcsx2_force_widescreen";
 static const char* BOOL_PCSX2_OPT_ENABLE_SPEEDHACKS = "pcsx2_enable_speedhacks";
 static const char* BOOL_PCSX2_OPT_FRAMESKIP = "pcsx2_frameskip";
 static const char* BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE = "pcsx2_userhack_align_sprite";
@@ -25,6 +24,7 @@ static const char* BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET = "pcsx2_userhack_wil
 static const char* STRING_PCSX2_OPT_BIOS = "pcsx2_bios";
 static const char* STRING_PCSX2_OPT_RENDERER = "pcsx2_renderer";
 
+static const char* INT_PCSX2_OPT_ASPECT_RATIO = "pcsx2_aspect_ratio";
 static const char* INT_PCSX2_OPT_UPSCALE_MULTIPLIER = "pcsx2_upscale_multiplier";
 static const char* INT_PCSX2_OPT_SPEEDHACKS_PRESET = "pcsx2_speedhacks_presets";
 static const char* INT_PCSX2_OPT_FRAMES_TO_DRAW = "pcsx2_frames_to_draw";

--- a/libretro/options_tools.h
+++ b/libretro/options_tools.h
@@ -15,6 +15,7 @@ extern retro_log_printf_t log_cb;
 extern void GSUpdateOptions();
 
 static const char* BOOL_PCSX2_OPT_FASTBOOT = "pcsx2_fastboot";
+static const char* BOOL_PCSX2_OPT_ENABLE_WIDESCREEN_PATCHES = "pcsx2_enable_widescreen_patches";
 static const char* BOOL_PCSX2_OPT_ENABLE_SPEEDHACKS = "pcsx2_enable_speedhacks";
 static const char* BOOL_PCSX2_OPT_FRAMESKIP = "pcsx2_frameskip";
 static const char* BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE = "pcsx2_userhack_align_sprite";


### PR DESCRIPTION
When enabled, this applies the appropriate widescreen patch (if available) from the system/pcsx2/cheats_wp directory (alternately from system/pcsx2/cheats_ws.zip).

For sake of clarity, the 'Force Widescreen' setting was given a more detailed description and was renamed 'Aspect Ratio' with the following options: 'Standard (4:3)' and 'Widescreen (16:9)'.