### PR TITLE
Added System Language Option

### DIFF
--- a/libretro/language_injector.cpp
+++ b/libretro/language_injector.cpp
@@ -153,7 +153,7 @@ namespace LanguageInjector
 			int checksum = 0;
 			for (size_t i = opt_index; i < opt_index + 15; i++) {
 				checksum += buffer[i] % 256;
-				log_cb(RETRO_LOG_DEBUG, "Calc checksum adding value: %x\n", buffer[i]);
+				//log_cb(RETRO_LOG_DEBUG, "Calc checksum adding value: %x\n", buffer[i]);
 			}
 			buffer[opt_index + 15] = checksum;
 			log_cb(RETRO_LOG_INFO, "checksum set to %x\n", checksum);

--- a/libretro/language_injector.cpp
+++ b/libretro/language_injector.cpp
@@ -1,0 +1,170 @@
+#include "language_injector.h"
+#include "options_tools.h"
+#include <fstream>
+#include <vector>
+#include <string>
+
+static const char* BIOS_30004R_V6		= "PS2 Bios 30004R V6 Pal";
+static const char* BIOS_SCPH70004_V12	= "SCPH-70004_BIOS_V12_PAL_200";
+
+static const uint8_t ADDRESS_SCPH70004_V12  = 0x2c;
+static const uint8_t ADDRESS_30004R_V6		= 0x31;
+
+static const char* LANG_ENGLISH		= "English";
+static const char* LANG_FRENCH		= "French";
+static const char* LANG_SPANISH		= "Spanish";
+static const char* LANG_GERMAN		= "German";
+static const char* LANG_ITALIAN		= "Italian";
+static const char* LANG_DUTCH		= "Dutch";
+static const char* LANG_PORTUGUESE	= "Portuguese";
+
+static const uint8_t BYTE_LANG_ENG = 0x21;
+static const uint8_t BYTE_LANG_FRA = 0x22;
+static const uint8_t BYTE_LANG_SPA = 0x23;
+static const uint8_t BYTE_LANG_GER = 0x24;
+static const uint8_t BYTE_LANG_ITA = 0x25;
+static const uint8_t BYTE_LANG_DUT = 0x26;
+static const uint8_t BYTE_LANG_POR = 0x27;
+
+
+static const int NUM_BIOS_LANG_ENTRIES = 14;
+
+
+const bios_lang bios_language[NUM_BIOS_LANG_ENTRIES] = {
+	{ BIOS_30004R_V6, LANG_ENGLISH,		ADDRESS_30004R_V6, BYTE_LANG_ENG },
+	{ BIOS_30004R_V6, LANG_FRENCH,		ADDRESS_30004R_V6, BYTE_LANG_FRA },
+	{ BIOS_30004R_V6, LANG_SPANISH,		ADDRESS_30004R_V6, BYTE_LANG_SPA },
+	{ BIOS_30004R_V6, LANG_GERMAN,		ADDRESS_30004R_V6, BYTE_LANG_GER },
+	{ BIOS_30004R_V6, LANG_ITALIAN,		ADDRESS_30004R_V6, BYTE_LANG_ITA },
+	{ BIOS_30004R_V6, LANG_DUTCH,		ADDRESS_30004R_V6, BYTE_LANG_DUT },
+	{ BIOS_30004R_V6, LANG_PORTUGUESE,	ADDRESS_30004R_V6, BYTE_LANG_POR },
+
+	{ BIOS_SCPH70004_V12, LANG_ENGLISH,		ADDRESS_SCPH70004_V12, BYTE_LANG_ENG },
+	{ BIOS_SCPH70004_V12, LANG_FRENCH,		ADDRESS_SCPH70004_V12, BYTE_LANG_FRA },
+	{ BIOS_SCPH70004_V12, LANG_SPANISH,		ADDRESS_SCPH70004_V12, BYTE_LANG_SPA },
+	{ BIOS_SCPH70004_V12, LANG_GERMAN,		ADDRESS_SCPH70004_V12, BYTE_LANG_GER },
+	{ BIOS_SCPH70004_V12, LANG_ITALIAN,		ADDRESS_SCPH70004_V12, BYTE_LANG_ITA },
+	{ BIOS_SCPH70004_V12, LANG_DUTCH,		ADDRESS_SCPH70004_V12, BYTE_LANG_DUT },
+	{ BIOS_SCPH70004_V12, LANG_PORTUGUESE,	ADDRESS_SCPH70004_V12, BYTE_LANG_POR  },
+
+};
+
+
+
+namespace LanguageInjector
+{
+	
+	void Inject(std::string bios_path, const char* language) {
+
+		size_t last_dot_index = bios_path.find_last_of(".");
+		std::string rawpath = bios_path.substr(0, last_dot_index);
+
+		size_t last_slash_index = rawpath.find_last_of("\\/");
+		std::string bios_name = rawpath.substr(last_slash_index + 1, rawpath.length());
+		log_cb(RETRO_LOG_DEBUG, "Isolated BIOS name: %s\n", bios_name.c_str());
+
+		bios_lang lang_data = _GetLanguageDataForBios(bios_name.c_str(), language);
+
+		if (lang_data.bios_name == NULL) {
+			log_cb(RETRO_LOG_INFO, "No injection data found for Bios %s - language: %s \n", bios_name.c_str(), language);
+		}
+		else
+		{
+			if (_ModifyNVM(bios_path, lang_data))
+				log_cb(RETRO_LOG_INFO, "Injected successfully language data for Bios %s - language: %s \n", bios_name.c_str(), language);
+		}
+
+	}
+
+
+
+
+	bios_lang _GetLanguageDataForBios(const char* bios_name, const char* language) {
+
+		for (int i = 0; i < NUM_BIOS_LANG_ENTRIES; i++) {
+			if (!strcmp(bios_language[i].bios_name, bios_name) && !strcmp(bios_language[i].language, language)) {
+				return bios_language[i];
+			}
+		}
+		return { NULL, NULL, NULL, NULL };
+
+	}
+
+
+	bool _ModifyNVM(std::string bios_path, bios_lang lang_data) {
+
+		size_t lastindex = bios_path.find_last_of(".");
+
+		std::string rawpath = bios_path.substr(0, lastindex);
+		std::string rawext = bios_path.substr(lastindex + 1, bios_path.length());
+		std::string nvm_ext = ".nvm";
+
+		if (_FirstUpper(rawext))
+			nvm_ext = ".NVM";
+
+		std::string path_nvm = rawpath + nvm_ext;
+		//std::string path_nvm_output = rawpath + "_DEBUG_OUT" + nvm_ext;
+		std::string path_nvm_output = rawpath + nvm_ext;
+
+		const int BUFFER_SIZE = 1024;
+		uint8_t buffer[BUFFER_SIZE];
+		std::ifstream infile(path_nvm, std::ifstream::binary);
+		infile.read((char*)buffer, BUFFER_SIZE);
+		infile.close();
+		log_cb(RETRO_LOG_DEBUG, "File read in buffer\n", buffer);
+
+		/*
+		log_cb(RETRO_LOG_DEBUG, "1 byte: %x\n", buffer[0]);
+		log_cb(RETRO_LOG_DEBUG, "2 byte: %x\n", buffer[1]);
+		log_cb(RETRO_LOG_DEBUG, "3 byte: %x\n", buffer[2]);
+		log_cb(RETRO_LOG_DEBUG, "4 byte: %x\n", buffer[3]);
+		log_cb(RETRO_LOG_DEBUG, "1 byte: %x\n", buffer[4]);
+		log_cb(RETRO_LOG_DEBUG, "2 byte: %x\n", buffer[5]);
+		log_cb(RETRO_LOG_DEBUG, "3 byte: %x\n", buffer[6]);
+		log_cb(RETRO_LOG_DEBUG, "4 byte: %x\n", buffer[7]);
+		*/
+
+		if (_ModifyLanguageOptionByte(buffer, lang_data)) {
+			std::ofstream outfile(path_nvm_output, std::ofstream::binary);
+			outfile.write((char*)buffer, BUFFER_SIZE);                      // write the actual text
+			outfile.close();
+			return true;
+		}
+		return false;
+
+	}
+
+
+	bool _ModifyLanguageOptionByte(uint8_t buffer[], bios_lang lang_data) {
+		size_t opt_index = (size_t)lang_data.address * 16;
+		log_cb(RETRO_LOG_DEBUG, "Checking language byte, found: %x\n", buffer[opt_index + 1]);
+		if (buffer[opt_index + 1] == lang_data.byte_lang) {
+			log_cb(RETRO_LOG_INFO, "Language already set to %s, no need to inject language byte\n", lang_data.language);
+		}
+		else
+		{
+			buffer[opt_index + 1] = lang_data.byte_lang;
+			log_cb(RETRO_LOG_INFO, "Language set to %s\n", lang_data.language);
+			int checksum = 0;
+			for (size_t i = opt_index; i < opt_index + 15; i++) {
+				checksum += buffer[i] % 256;
+				log_cb(RETRO_LOG_DEBUG, "Calc checksum adding value: %x\n", buffer[i]);
+			}
+			buffer[opt_index + 15] = checksum;
+			log_cb(RETRO_LOG_INFO, "checksum set to %x\n", checksum);
+			return true;
+		}
+		return false;
+	}
+
+	bool _FirstUpper(const std::string& word) {
+		return word.size() && std::isupper(word[0]);
+	}
+
+
+	
+
+
+
+
+} // closing namespace

--- a/libretro/language_injector.cpp
+++ b/libretro/language_injector.cpp
@@ -1,3 +1,10 @@
+/*
+* Language Injector by SeventySixx
+* According to the provided BIOS path and language option, injects the relative 
+* language byte in the nvm BIOS file. If a BIOS is not supported, or if the requested 
+* language is already set, it exits without doing nothing. 
+*/
+
 #include "language_injector.h"
 #include "options_tools.h"
 #include <fstream>
@@ -6,9 +13,11 @@
 
 static const char* BIOS_30004R_V6		= "PS2 Bios 30004R V6 Pal";
 static const char* BIOS_SCPH70004_V12	= "SCPH-70004_BIOS_V12_PAL_200";
+static const char* BIOS_SCPH39001		= "scph39001";
 
 static const uint8_t ADDRESS_SCPH70004_V12  = 0x2c;
 static const uint8_t ADDRESS_30004R_V6		= 0x31;
+static const uint8_t ADDRESS_SCPH39001		= 0x31;
 
 static const char* LANG_ENGLISH		= "English";
 static const char* LANG_FRENCH		= "French";
@@ -27,7 +36,7 @@ static const uint8_t BYTE_LANG_DUT = 0x26;
 static const uint8_t BYTE_LANG_POR = 0x27;
 
 
-static const int NUM_BIOS_LANG_ENTRIES = 14;
+static const int NUM_BIOS_LANG_ENTRIES = 21;
 
 
 const bios_lang bios_language[NUM_BIOS_LANG_ENTRIES] = {
@@ -47,6 +56,13 @@ const bios_lang bios_language[NUM_BIOS_LANG_ENTRIES] = {
 	{ BIOS_SCPH70004_V12, LANG_DUTCH,		ADDRESS_SCPH70004_V12, BYTE_LANG_DUT },
 	{ BIOS_SCPH70004_V12, LANG_PORTUGUESE,	ADDRESS_SCPH70004_V12, BYTE_LANG_POR  },
 
+	{ BIOS_SCPH39001, LANG_ENGLISH,		ADDRESS_SCPH39001, BYTE_LANG_ENG },
+	{ BIOS_SCPH39001, LANG_FRENCH,		ADDRESS_SCPH39001, BYTE_LANG_FRA },
+	{ BIOS_SCPH39001, LANG_SPANISH,		ADDRESS_SCPH39001, BYTE_LANG_SPA },
+	{ BIOS_SCPH39001, LANG_GERMAN,		ADDRESS_SCPH39001, BYTE_LANG_GER },
+	{ BIOS_SCPH39001, LANG_ITALIAN,		ADDRESS_SCPH39001, BYTE_LANG_ITA },
+	{ BIOS_SCPH39001, LANG_DUTCH,		ADDRESS_SCPH39001, BYTE_LANG_DUT },
+	{ BIOS_SCPH39001, LANG_PORTUGUESE,	ADDRESS_SCPH39001, BYTE_LANG_POR  },
 };
 
 
@@ -75,8 +91,6 @@ namespace LanguageInjector
 		}
 
 	}
-
-
 
 
 	bios_lang _GetLanguageDataForBios(const char* bios_name, const char* language) {
@@ -113,17 +127,6 @@ namespace LanguageInjector
 		infile.close();
 		log_cb(RETRO_LOG_DEBUG, "File read in buffer\n", buffer);
 
-		/*
-		log_cb(RETRO_LOG_DEBUG, "1 byte: %x\n", buffer[0]);
-		log_cb(RETRO_LOG_DEBUG, "2 byte: %x\n", buffer[1]);
-		log_cb(RETRO_LOG_DEBUG, "3 byte: %x\n", buffer[2]);
-		log_cb(RETRO_LOG_DEBUG, "4 byte: %x\n", buffer[3]);
-		log_cb(RETRO_LOG_DEBUG, "1 byte: %x\n", buffer[4]);
-		log_cb(RETRO_LOG_DEBUG, "2 byte: %x\n", buffer[5]);
-		log_cb(RETRO_LOG_DEBUG, "3 byte: %x\n", buffer[6]);
-		log_cb(RETRO_LOG_DEBUG, "4 byte: %x\n", buffer[7]);
-		*/
-
 		if (_ModifyLanguageOptionByte(buffer, lang_data)) {
 			std::ofstream outfile(path_nvm_output, std::ofstream::binary);
 			outfile.write((char*)buffer, BUFFER_SIZE);                      // write the actual text
@@ -136,8 +139,10 @@ namespace LanguageInjector
 
 
 	bool _ModifyLanguageOptionByte(uint8_t buffer[], bios_lang lang_data) {
+
 		size_t opt_index = (size_t)lang_data.address * 16;
 		log_cb(RETRO_LOG_DEBUG, "Checking language byte, found: %x\n", buffer[opt_index + 1]);
+
 		if (buffer[opt_index + 1] == lang_data.byte_lang) {
 			log_cb(RETRO_LOG_INFO, "Language already set to %s, no need to inject language byte\n", lang_data.language);
 		}
@@ -157,13 +162,10 @@ namespace LanguageInjector
 		return false;
 	}
 
+
 	bool _FirstUpper(const std::string& word) {
 		return word.size() && std::isupper(word[0]);
 	}
-
-
-	
-
 
 
 

--- a/libretro/language_injector.h
+++ b/libretro/language_injector.h
@@ -1,0 +1,25 @@
+#include <cstdint>
+#include <string>
+#pragma once
+
+
+struct bios_lang {
+	const char* bios_name;
+	const char* language;
+	const uint8_t address;
+	const uint8_t byte_lang;
+};
+
+namespace LanguageInjector
+{
+	void Inject(std::string bios_path, const char* language);
+	
+	bool _ModifyNVM(std::string bios_path, bios_lang lang_data);
+	bios_lang _GetLanguageDataForBios(const char* bios_name, const char* language);
+	bool _ModifyLanguageOptionByte(uint8_t buffer[], bios_lang lang_data);
+	bool _FirstUpper(const std::string& word);
+	
+
+}
+
+

--- a/libretro/language_injector.h
+++ b/libretro/language_injector.h
@@ -14,6 +14,7 @@ namespace LanguageInjector
 {
 	void Inject(std::string bios_path, const char* language);
 	
+	
 	bool _ModifyNVM(std::string bios_path, bios_lang lang_data);
 	bios_lang _GetLanguageDataForBios(const char* bios_name, const char* language);
 	bool _ModifyLanguageOptionByte(uint8_t buffer[], bios_lang lang_data);

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -17,6 +17,21 @@ struct retro_core_option_definition option_defs[] = {
 	},
 	NULL},
 
+	{"pcsx2_system_language",
+	"System Language",
+	"Set the BIOS system Language. Useful for PAL multilanguage games. The selected language will be applied, if available in-game. (Content restart required)",
+	{
+		{"English", NULL},
+		{"French", NULL},
+		{"Spanish", NULL},
+		{"German", NULL},
+		{"Italian", NULL},
+		{"Dutch", NULL},
+		{"Portuguese", NULL},
+		{NULL, NULL},
+	},
+	"Keep BIOS setting"},
+
 	{"pcsx2_fastboot",
 	"Fast Boot",
 	"This will bypass the intial BIOS logo, with the side effect that BIOS settings like the system language will not be applied. (Content restart required)",
@@ -40,7 +55,7 @@ struct retro_core_option_definition option_defs[] = {
 		{"Null", NULL},
 		{NULL, NULL},
 	},
-	"auto"},
+	"Auto"},
 
 	{"pcsx2_upscale_multiplier",
 	"Internal Resolution ",
@@ -69,7 +84,7 @@ struct retro_core_option_definition option_defs[] = {
 
 	{"pcsx2_enable_widescreen_patches",
 	"Enable Widescreen Patches",
-	"Enables widescreen patches that allow certain games to render in true 16:9 ratio without stretching the display. For the widescreen patches to display properly, the 'Aspect Ratio' option should be set to Widescreen (16:9). (Content restart required)",
+	"Enables widescreen patches that allow certain games to render in true 16:9 ratio without stretching the display. For the widescreen patches to display properly, the 'Aspect Ratio' option should be set to Widescreen (16:9). Considerably increases games boot time. (Content restart required)",
 	{
 		{"disabled", NULL},
 		{"enabled", NULL},

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -20,11 +20,14 @@
 
 #include "GS.h"
 #include "options_tools.h"
+#include "language_injector.h"
 #include "input.h"
 #include "svnrev.h"
 #include "disk_control.h"
 #include "SPU2/Global.h"
 #include "ps2/BiosTools.h"
+
+
 
 #include "MTVU.h"
 
@@ -163,6 +166,7 @@ void retro_init(void)
 	};
 
 	environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE, &disk_control);
+
 }
 
 void retro_deinit(void)
@@ -349,6 +353,7 @@ read_m3u_file(const wxFileName& m3u_file)
 
 bool retro_load_game(const struct retro_game_info* game)
 {
+
 	const char* selected_bios = option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type);
 	if (selected_bios == NULL)
 	{
@@ -372,6 +377,12 @@ bool retro_load_game(const struct retro_game_info* game)
 
 	if (game)
 	{
+
+		LanguageInjector::Inject(
+			(std::string)option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type),
+			option_value(STRING_PCSX2_OPT_SYSTEM_LANGUAGE, KeyOptionString::return_type)
+		);
+
 		wxVector<wxString> game_paths;
 
 		wxFileName file_name(game->path);

--- a/libretro/options_tools.h
+++ b/libretro/options_tools.h
@@ -14,31 +14,32 @@ extern retro_environment_t environ_cb;
 extern retro_log_printf_t log_cb;
 extern void GSUpdateOptions();
 
-static const char* BOOL_PCSX2_OPT_FASTBOOT = "pcsx2_fastboot";
+static const char* BOOL_PCSX2_OPT_FASTBOOT					= "pcsx2_fastboot";
 static const char* BOOL_PCSX2_OPT_ENABLE_WIDESCREEN_PATCHES = "pcsx2_enable_widescreen_patches";
-static const char* BOOL_PCSX2_OPT_ENABLE_SPEEDHACKS = "pcsx2_enable_speedhacks";
-static const char* BOOL_PCSX2_OPT_FRAMESKIP = "pcsx2_frameskip";
-static const char* BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE = "pcsx2_userhack_align_sprite";
-static const char* BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE = "pcsx2_userhack_merge_sprite";
-static const char* BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET = "pcsx2_userhack_wildarms_offset";
-static const char* BOOL_PCSX2_OPT_GAMEPAD_RUMBLE_ENABLE = "pcsx2_rumble_enable";
+static const char* BOOL_PCSX2_OPT_ENABLE_SPEEDHACKS			= "pcsx2_enable_speedhacks";
+static const char* BOOL_PCSX2_OPT_FRAMESKIP					= "pcsx2_frameskip";
+static const char* BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE		= "pcsx2_userhack_align_sprite";
+static const char* BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE		= "pcsx2_userhack_merge_sprite";
+static const char* BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET	= "pcsx2_userhack_wildarms_offset";
+static const char* BOOL_PCSX2_OPT_GAMEPAD_RUMBLE_ENABLE		= "pcsx2_rumble_enable";
 
-static const char* STRING_PCSX2_OPT_BIOS = "pcsx2_bios";
-static const char* STRING_PCSX2_OPT_RENDERER = "pcsx2_renderer";
+static const char* STRING_PCSX2_OPT_BIOS					= "pcsx2_bios";
+static const char* STRING_PCSX2_OPT_RENDERER				= "pcsx2_renderer";
+static const char* STRING_PCSX2_OPT_SYSTEM_LANGUAGE			= "pcsx2_system_language";
 
-static const char* INT_PCSX2_OPT_ASPECT_RATIO = "pcsx2_aspect_ratio";
-static const char* INT_PCSX2_OPT_UPSCALE_MULTIPLIER = "pcsx2_upscale_multiplier";
-static const char* INT_PCSX2_OPT_SPEEDHACKS_PRESET = "pcsx2_speedhacks_presets";
-static const char* INT_PCSX2_OPT_FRAMES_TO_DRAW = "pcsx2_frames_to_draw";
-static const char* INT_PCSX2_OPT_FRAMES_TO_SKIP = "pcsx2_frames_to_skip";
-static const char* INT_PCSX2_OPT_RENDERER_THREADS = "pcsx2_sw_renderer_threads";
-static const char* INT_PCSX2_OPT_ANISOTROPIC_FILTER = "pcsx2_anisotropic_filter";
-static const char* INT_PCSX2_OPT_USERHACK_SKIPDRAW_START = "pcsx2_userhack_skipdraw_start";
-static const char* INT_PCSX2_OPT_USERHACK_SKIPDRAW_LAYERS = "pcsx2_userhack_skipdraw_layers";
-static const char* INT_PCSX2_OPT_USERHACK_HALFPIXEL_OFFSET = "pcsx2_userhack_halfpixel_offset";
-static const char* INT_PCSX2_OPT_USERHACK_ROUND_SPRITE = "pcsx2_userhack_round_sprite";
-static const char* INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX = "pcsx2_userhack_halfscreen_fix";
-static const char* INT_PCSX2_OPT_GAMEPAD_RUMBLE_FORCE = "pcsx2_rumble_intensity";
+static const char* INT_PCSX2_OPT_ASPECT_RATIO				= "pcsx2_aspect_ratio";
+static const char* INT_PCSX2_OPT_UPSCALE_MULTIPLIER			= "pcsx2_upscale_multiplier";
+static const char* INT_PCSX2_OPT_SPEEDHACKS_PRESET			= "pcsx2_speedhacks_presets";
+static const char* INT_PCSX2_OPT_FRAMES_TO_DRAW				= "pcsx2_frames_to_draw";
+static const char* INT_PCSX2_OPT_FRAMES_TO_SKIP				= "pcsx2_frames_to_skip";
+static const char* INT_PCSX2_OPT_RENDERER_THREADS			= "pcsx2_sw_renderer_threads";
+static const char* INT_PCSX2_OPT_ANISOTROPIC_FILTER			= "pcsx2_anisotropic_filter";
+static const char* INT_PCSX2_OPT_USERHACK_SKIPDRAW_START	= "pcsx2_userhack_skipdraw_start";
+static const char* INT_PCSX2_OPT_USERHACK_SKIPDRAW_LAYERS	= "pcsx2_userhack_skipdraw_layers";
+static const char* INT_PCSX2_OPT_USERHACK_HALFPIXEL_OFFSET	= "pcsx2_userhack_halfpixel_offset";
+static const char* INT_PCSX2_OPT_USERHACK_ROUND_SPRITE		= "pcsx2_userhack_round_sprite";
+static const char* INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX	= "pcsx2_userhack_halfscreen_fix";
+static const char* INT_PCSX2_OPT_GAMEPAD_RUMBLE_FORCE		= "pcsx2_rumble_intensity";
 
 
 

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -989,7 +989,7 @@ if(LIBRETRO)
      
      ${CMAKE_SOURCE_DIR}/libretro/input.cpp
      ${pcsx2FinalSources}
-   )
+    "../libretro/language_injector.cpp")
    include_directories(. ${CMAKE_SOURCE_DIR}/libretro)
 #   set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}")
    set_target_properties(pcsx2_libretro PROPERTIES PREFIX "")

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -471,12 +471,12 @@ EXPORT_C_(int) GSopen2(void** dsp, uint32 flags)
 			if (! std::strcmp(option_value(STRING_PCSX2_OPT_RENDERER, KeyOptionString::return_type), "Software"))
 			{
 				theApp.SetCurrentRendererType(GSRendererType::OGL_SW);
-				log_cb(RETRO_LOG_ERROR, "Selected Renderer: OGL_SW\n");
+				log_cb(RETRO_LOG_INFO, "Selected Renderer: OGL_SW\n");
 			}
 			else
 			{
 				theApp.SetCurrentRendererType(GSRendererType::OGL_HW);
-				log_cb(RETRO_LOG_ERROR, "Selected Renderer: OGL_HW\n");
+				log_cb(RETRO_LOG_INFO, "Selected Renderer: OGL_HW\n");
 			}
 			break;
 	}


### PR DESCRIPTION
This option allows to change the language per-game,  by injecting at boot time the corresponding language byte in the nvm file of the  BIOS currently in use for the content. If a BIOS is not supported, or if the requested language is already set, it doesn't make changes.

The BIOS supported are all those listed in the PCSX2 libretro docs (https://docs.libretro.com/library/pcsx2/) excluded the Japanese scph10000.