### PR TITLE
CDVD: Adjust read speed depending on if in inner/outer edge

### DIFF
--- a/bin/GameIndex.dbf
+++ b/bin/GameIndex.dbf
@@ -36020,7 +36020,6 @@ Serial = SLUS-20217
 Name   = Arctic Thunder
 Region = NTSC-U
 Compat = 5
-SkipMPEGHack = 1
 ---------------------------------------------
 Serial = SLUS-20218
 Name   = Stunt GP

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -592,7 +592,35 @@ static s32 cdvdReadDvdDualInfo(s32* dualType, u32* layer1Start)
 
 static uint cdvdBlockReadTime(CDVD_MODE_TYPE mode)
 {
-	return (PSXCLK * cdvd.BlockSize) / (((mode == MODE_CDROM) ? PSX_CD_READSPEED : PSX_DVD_READSPEED) * cdvd.Speed);
+	int numSectors = 0;
+	int offset = 0;
+	// Sector counts are taken from google for Single layer, Dual layer DVD's and for 700MB CD's
+	switch (cdvd.Type)
+	{
+	case CDVD_TYPE_DETCTDVDS:
+	case CDVD_TYPE_PS2DVD:
+		numSectors = 2298496;
+		break;
+	case CDVD_TYPE_DETCTDVDD:
+		numSectors = 4173824 / 2; // Total sectors for both layers, assume half per layer
+		u32 layer1Start;
+		s32 dualType;
+
+		// Layer 1 needs an offset as it goes back to the middle of the disc
+		cdvdReadDvdDualInfo(&dualType, &layer1Start);
+		if (cdvd.Sector >= layer1Start)
+			offset = layer1Start;
+		break;
+	default: // Pretty much every CD format
+		numSectors = 360000;
+		break;
+	}
+	// Read speed is roughly 37% at lowest and full speed on outer edge. I imagine it's more logarithmic than this
+	// Required for Shadowman to work
+	// Use SeekToSector as Sector hasn't been updated yet
+	const float sectorSpeed = (((float)(cdvd.SeekToSector - offset) / numSectors) * 0.63f) + 0.37f;
+	//DevCon.Warning("Read speed %f sector %d\n", sectorSpeed, cdvd.Sector);
+	return ((PSXCLK * cdvd.BlockSize) / ((float)(((mode == MODE_CDROM) ? PSX_CD_READSPEED : PSX_DVD_READSPEED) * cdvd.Speed) * sectorSpeed));
 }
 
 void cdvdReset()

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -123,13 +123,8 @@ static const uint tbl_ContigiousSeekDelta[3] =
 // concerned with accurate(ish) seek delays and less concerned with actual block read speeds.
 // Translation: it's a minor speedhack :D
 
-//Fixme ( voodoocycles ):
-//The current CD mode gives a too low transfer rate. HDloader reports 900kb/s, while the theoretical max is 3600kb/s
-//Silent Hill 2 videos starve of data and stall.
-//So let's double that until the cause of the slow data rate is known.
-
-static const uint PSX_CD_READSPEED = 153600 * 2;        // 1 Byte Time @ x1 (150KB = cd x 1)
-static const uint PSX_DVD_READSPEED = 1382400 + 256000; // normal is 1 Byte Time @ x1 (1350KB = dvd x 1).
+static const uint PSX_CD_READSPEED = 153600;   // 1 Byte Time @ x1 (150KB = cd x 1)
+static const uint PSX_DVD_READSPEED = 1382400; // 1 Byte Time @ x1 (1350KB = dvd x 1).
 
 // Legacy Note: FullSeek timing causes many games to load very slow, but it likely not the real problem.
 // Games breaking with it set to PSXCLK*40 : "wrath unleashed" and "Shijou Saikyou no Deshi Kenichi".


### PR DESCRIPTION
Backport of PCSX2/pcsx2#3877 that fixes a number of CDVD timing issues, e.g. the missing sound in Klonoa 2. Removes a GameDB hack for Arctic Thunder as it's no longer needed. Addresses #42 