### PR TITLE
IPU: Return contents of the bottom of the FIFO in CMD except FDEC/VDEC

### DIFF
--- a/pcsx2/IPU/IPU.cpp
+++ b/pcsx2/IPU/IPU.cpp
@@ -204,6 +204,16 @@ __fi u32 ipuRead32(u32 mem)
 
 	switch (mem)
 	{
+		ipucase(IPU_CMD) : // IPU_CMD
+		{
+			if (ipu_cmd.CMD != SCE_IPU_FDEC && ipu_cmd.CMD != SCE_IPU_VDEC)
+			{
+				if (getBits32((u8*)&ipuRegs.cmd.DATA, 0))
+					ipuRegs.cmd.DATA = BigEndian(ipuRegs.cmd.DATA);
+			}
+			return ipuRegs.cmd.DATA;
+		}
+
 		ipucase(IPU_CTRL): // IPU_CTRL
 		{
 			ipuRegs.ctrl.IFC = g_BP.IFC;
@@ -247,9 +257,17 @@ __fi u64 ipuRead64(u32 mem)
 	switch (mem)
 	{
 		ipucase(IPU_CMD): // IPU_CMD
+		{
+			if (ipu_cmd.CMD != SCE_IPU_FDEC && ipu_cmd.CMD != SCE_IPU_VDEC)
+			{
+				if (getBits32((u8*)&ipuRegs.cmd.DATA, 0))
+					ipuRegs.cmd.DATA = BigEndian(ipuRegs.cmd.DATA);
+			}
+
 			if (ipuRegs.cmd.DATA & 0xffffff)
 				IPU_LOG("read64: IPU_CMD=BUSY=%x, DATA=%08X", ipuRegs.cmd.BUSY ? 1 : 0, ipuRegs.cmd.DATA);
-			break;
+			return ipuRegs.cmd._u64;
+		}
 
 		ipucase(IPU_CTRL):
 			DevCon.Warning("reading 64bit IPU ctrl");
@@ -979,6 +997,6 @@ __noinline void IPUWorker()
 
 	// success
 	ipuRegs.ctrl.BUSY = 0;
-	ipu_cmd.current = 0xffffffff;
+	//ipu_cmd.current = 0xffffffff;
 	hwIntcIrq(INTC_IPU);
 }

--- a/pcsx2/IPU/IPU.h
+++ b/pcsx2/IPU/IPU.h
@@ -29,12 +29,16 @@
 // Bitfield Structures
 //
 
-struct tIPU_CMD
+union tIPU_CMD
 {
-	u32 DATA;
-	u32 BUSY;
-	
-	void SetBusy(bool busy=true)
+	struct
+	{
+		u32 DATA;
+		u32 BUSY;
+	};
+	u64 _u64;
+
+	void SetBusy(bool busy = true)
 	{
 		BUSY = busy ? 0x80000000 : 0;
 	}


### PR DESCRIPTION
Backport of PCSX2/pcsx2#4066. Fixes the FMVs in Shox (see #39)