### PR TITLE
(.gitlab-ci.yml) Enable libretro-build-linux-x64 target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
   extends: .core-defs
   variables:
     EXTRA_PATH: pcsx2
-    CORE_ARGS: -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_QT=OFF
+    CORE_ARGS: -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_QT=OFF -DCMAKE_LINK_WHAT_YOU_USE=TRUE
 
 .core-windows-defs:
   extends: .core-defs
@@ -53,7 +53,7 @@ libretro-build-windows-x64:
     - .core-windows-defs
 
 # Linux 64-bit
-#libretro-build-linux-x64:
-#  extends:
-#    - .libretro-linux-cmake-x86_64
-#    - .core-linux-defs
+libretro-build-linux-x64:
+  extends:
+    - .libretro-linux-cmake-x86_64
+    - .core-linux-defs

--- a/libretro/options_tools.h
+++ b/libretro/options_tools.h
@@ -9,6 +9,7 @@
 
 #include <libretro.h>
 #include <stdlib.h>
+#include <cstring>
 
 extern retro_environment_t environ_cb;
 extern retro_log_printf_t log_cb;


### PR DESCRIPTION
This PR enables the `libretro-build-linux-x64` target in the `.gitlab-ci.yml` file.

I am unable to test the core, but it at least builds successfully for Linux on the new build infra now. The fixes here are entirely the work of neoXite.