### PR TITLE
Workaround for crashes on "Close Content"

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -385,7 +385,13 @@ void retro_init(void)
 
 void retro_deinit(void)
 {
-	vu1Thread.Cancel();
+	/* FIXME: This is a workaround that resolves crashes on close content
+	 When closing the frontend, but we end up with a zombie process because
+	the main thread tries to call vu1Thread.Cancel() when pcsx2's destructor is
+	called, but it gets stuck waiting for a mutex that will never unlock */
+	vu1Thread.WaitVU();
+	//vu1Thread.Cancel();
+
 	pcsx2->CleanupOnExit();
 	pcsx2->OnExit();
 #ifdef PERF_TEST

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -385,10 +385,10 @@ void retro_init(void)
 
 void retro_deinit(void)
 {
-	/* FIXME: This is a workaround that resolves crashes on close content
-	 When closing the frontend, but we end up with a zombie process because
-	the main thread tries to call vu1Thread.Cancel() when pcsx2's destructor is
-	called, but it gets stuck waiting for a mutex that will never unlock */
+	/* FIXME: This is a workaround that resolves crashes on close content.
+	When closing the frontend, we end up with a zombie process because the
+	main thread tries to call vu1Thread.Cancel() within pcsx2's destructor is
+	called and it gets stuck waiting for a mutex that will never unlock */
 	vu1Thread.WaitVU();
 	//vu1Thread.Cancel();
 


### PR DESCRIPTION
Workaround that appears to fix most crashes on `Close Content` on Windows 10 and Xbox. I haven't tested this on Linux.

This is, by no means, a proper fix, as it appears to leave behind a zombie process more frequently when closing Retroarch. A more robust solution is needed in the long run, but for now, I believe this is the lesser of two evils. Some testing results on my end:

In the most recent build before this PR, the Windows 10 build would frequently crash on `Close Content` or hang when running content after previously closing content, particularly when MTVU was on. The Xbox build would almost always crash or hang when closing content or when loading content after having previously closed content in pcsx2.

With speedhacks enabled and set to the `Balanced` preset (as to enable MTVU), I tested 21 games on Xbox Series X. In sequence, I managed to boot 20/21 of them to menu, close content, and launch the next game without a single crash or hang. The only game in my testing that failed to close was Jak II, which hung on `Close Content`. This does not appear to be a regression, since Jak II also hung on `Close Content` with the previous build.

Some notes:

1. `Restart Content` still deadlocks. This workaround doesn't fix that
2. There appear to be issues with switching from the pcsx2 core to other hardware-rendered cores (e.g. Dolphin). I've seen reports of this on Discord with builds prior to this PR, so I don't believe this is a regression from this workaround. Other cores seem to load just fine after switching from the pcsx2 core