### PR TITLE
Options revisions + 'Hack: Auto Flush' option

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -62,8 +62,6 @@ struct retro_core_option_definition option_defs[] = {
 		{"D3D11", NULL},
 #endif
 		{"OpenGl", NULL},
-		{"Software", NULL},
-		{"Null", NULL},
 		{NULL, NULL},
 	},
 	"Auto"},
@@ -111,7 +109,7 @@ struct retro_core_option_definition option_defs[] = {
 
 	{"pcsx2_enable_widescreen_patches",
 	"Enable Widescreen Patches",
-	"Enables widescreen patches that allow certain games to render in true 16:9 ratio without stretching the display. For the widescreen patches to display properly, the 'Aspect Ratio' option should be set to Widescreen (16:9). Considerably increases games boot time. (Content restart required)",
+	"Enables widescreen patches that allow certain games to render in true 16:9 ratio without stretching the display. For the widescreen patches to display properly, the 'Aspect Ratio' option should be set to Widescreen (16:9). (Content restart required)",
 	{
 		{"disabled", NULL},
 		{"enabled", NULL},
@@ -131,7 +129,7 @@ struct retro_core_option_definition option_defs[] = {
 
 	{"pcsx2_anisotropic_filter",
 	 "Anisotropic Filtering",
-	 "D3D11 only. Reduces texture aliasing at extreme viewing angles",
+	 "Reduces texture aliasing at extreme viewing angles",
 	{
 		{"0", "None"},
 		{"2", "2x"},
@@ -144,7 +142,7 @@ struct retro_core_option_definition option_defs[] = {
 
 	{"pcsx2_memcard_slot_1",
 	"Memory Card: Slot 1",
-	"Select the primary memory card to use. 'Legacy' points to the memory card Mcd001 in the old location system/pcsx2/memcards. (content restart required)",
+	"Select the primary memory card to use. 'Legacy' points to the memory card Mcd001 in the old location system/pcsx2/memcards. (Content restart required)",
 	{
 		// dynamically filled in retro_init
 	},
@@ -152,7 +150,7 @@ struct retro_core_option_definition option_defs[] = {
 
 	{ "pcsx2_memcard_slot_2",
 	"Memory Card: Slot 2",
-	"Select the secondary memory card to use. 'Legacy' points to the memory card Mcd002 in the old location system/pcsx2/memcards. (content restart required)",
+	"Select the secondary memory card to use. 'Legacy' points to the memory card Mcd002 in the old location system/pcsx2/memcards. (Content restart required)",
 	{
 		// dynamically filled in retro_init
 	},
@@ -188,7 +186,8 @@ struct retro_core_option_definition option_defs[] = {
 
 	{ "pcsx2_enable_cheats",
 	"Enable Cheats",
-	"Loads and apply cheats pnach files found in the cheats folder. (content restart required)",
+	"Enabled: Checks the 'system/pcsx2/cheats' directory for a PNACH file for the running content and, if found, \
+	applies the cheats from the file. (Content restart required)",
 	{
 		{"disabled", NULL},
 		{"enabled", NULL},
@@ -196,19 +195,14 @@ struct retro_core_option_definition option_defs[] = {
 	},
 	"disabled" },
 
-	{"pcsx2_enable_speedhacks",
-	"Enable SpeedHacks",
-	"Speedhacks usually improve emulation speed, but can cause glitches, broken audio, and false FPS readings. When having emulation problems, or the BIOS menu text is not visible, disable this option. (content restart required)",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled"},
-
 	{"pcsx2_speedhacks_presets",
-	 "SpeedHacks preset",
-	 "Preset which controls the speedhacks balance between accurancy and speed. This setting is applied only if 'Enable Speedhacks' option is enabled. (content restart required)",
+	 "Speed Hacks Preset",
+	 "Preset which controls the balance between accuracy and speed. (Content restart required) \
+		\nSafest: no speed hacks. Most reliable, but possibly slow. \
+		\nSafe: a few speed hacks known to provide boosts with minimal to no side effects. \
+		\nBalanced: recommended preset for CPUs with 4+ cores. Provides good boosts with minimal to no side effects. \
+		\nAggressive/Very Aggressive: may help underpowered CPUs in less demanding games, but may cause problems in other cases. \
+		\nMostly Harmful: helps a very small set of games with unusual performance requirements. Not recommended for underpowered devices.",
 	{
 		{"0", "Safest - No Hacks"},
 		{"1", "Safe (default)"},
@@ -262,24 +256,6 @@ struct retro_core_option_definition option_defs[] = {
 		{"8", NULL},
 		{"9", NULL},
 		{"10", NULL},
-		{NULL, NULL},
-	},
-	"1" },
-
-	{ "pcsx2_sw_renderer_threads",
-	"Software Rendered Threads",
-	NULL,
-	{
-		{"2", NULL},
-		{"3", NULL},
-		{"4", NULL},
-		{"5", NULL},
-		{"6", NULL},
-		{"7", NULL},
-		{"8", NULL},
-		{"9", NULL},
-		{"10", NULL},
-		{"11", NULL},
 		{NULL, NULL},
 	},
 	"1" },
@@ -405,7 +381,7 @@ struct retro_core_option_definition option_defs[] = {
 		{"1", "Force-Enabled"},
 		{NULL, NULL},
 	},
-	"disabled" },
+	"-1" },
 
 	{NULL, NULL, NULL, {{0}}, NULL},
 };

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -383,6 +383,17 @@ struct retro_core_option_definition option_defs[] = {
 	},
 	"-1" },
 
+	{ "pcsx2_userhack_auto_flush",
+	"Hack: Auto Flush",
+	"Force a primitive flush when a framebuffer is also an input texture. Fixes some processing effects such as the shadows in the \
+	Jak series and radiosity in GTA:SA. Very costly in performance. (Content restart required)",
+	{
+		{"disabled", NULL},
+		{"enabled", NULL},
+		{NULL, NULL},
+	},
+	"disabled" },
+
 	{NULL, NULL, NULL, {{0}}, NULL},
 };
 

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -385,8 +385,8 @@ void retro_deinit(void)
 {
 	/* FIXME: This is a workaround that resolves crashes on close content.
 	When closing the frontend, we end up with a zombie process because the
-	main thread tries to call vu1Thread.Cancel() within pcsx2's destructor is
-	called and it gets stuck waiting for a mutex that will never unlock */
+	main thread tries to call vu1Thread.Cancel() within pcsx2's destructor
+	and it gets stuck waiting for a mutex that will never unlock */
 	vu1Thread.WaitVU();
 	//vu1Thread.Cancel();
 

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -349,10 +349,8 @@ void retro_init(void)
 
 
 	// apply options to pcsx2
-
-	if (!option_value(BOOL_PCSX2_OPT_ENABLE_SPEEDHACKS, KeyOptionBool::return_type))
-		g_Conf->PresetIndex = 1;
-
+	
+	g_Conf->EnablePresets = true;
 	g_Conf->BaseFilenames.Plugins[PluginId_GS] = "Built-in";
 	g_Conf->BaseFilenames.Plugins[PluginId_PAD] = "Built-in";
 	g_Conf->BaseFilenames.Plugins[PluginId_USB] = "Built-in";

--- a/libretro/options_tools.h
+++ b/libretro/options_tools.h
@@ -26,6 +26,7 @@ static const char* BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET	= "pcsx2_userhack_wil
 static const char* BOOL_PCSX2_OPT_GAMEPAD_RUMBLE_ENABLE		= "pcsx2_rumble_enable";
 static const char* BOOL_PCSX2_OPT_BOOT_TO_BIOS				= "pcsx2_boot_bios";
 static const char* BOOL_PCSX2_OPT_ENABLE_CHEATS				= "pcsx2_enable_cheats";
+static const char* BOOL_PCSX2_OPT_USERHACK_AUTO_FLUSH		= "pcsx2_userhack_auto_flush";
 
 
 

--- a/libretro/options_tools.h
+++ b/libretro/options_tools.h
@@ -19,7 +19,6 @@ extern void ResetContentStuffs();
 
 static const char* BOOL_PCSX2_OPT_FASTBOOT					= "pcsx2_fastboot";
 static const char* BOOL_PCSX2_OPT_ENABLE_WIDESCREEN_PATCHES = "pcsx2_enable_widescreen_patches";
-static const char* BOOL_PCSX2_OPT_ENABLE_SPEEDHACKS			= "pcsx2_enable_speedhacks";
 static const char* BOOL_PCSX2_OPT_FRAMESKIP					= "pcsx2_frameskip";
 static const char* BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE		= "pcsx2_userhack_align_sprite";
 static const char* BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE		= "pcsx2_userhack_merge_sprite";
@@ -42,7 +41,6 @@ static const char* INT_PCSX2_OPT_UPSCALE_MULTIPLIER			= "pcsx2_upscale_multiplie
 static const char* INT_PCSX2_OPT_SPEEDHACKS_PRESET			= "pcsx2_speedhacks_presets";
 static const char* INT_PCSX2_OPT_FRAMES_TO_DRAW				= "pcsx2_frames_to_draw";
 static const char* INT_PCSX2_OPT_FRAMES_TO_SKIP				= "pcsx2_frames_to_skip";
-static const char* INT_PCSX2_OPT_RENDERER_THREADS			= "pcsx2_sw_renderer_threads";
 static const char* INT_PCSX2_OPT_ANISOTROPIC_FILTER			= "pcsx2_anisotropic_filter";
 static const char* INT_PCSX2_OPT_USERHACK_SKIPDRAW_START	= "pcsx2_userhack_skipdraw_start";
 static const char* INT_PCSX2_OPT_USERHACK_SKIPDRAW_LAYERS	= "pcsx2_userhack_skipdraw_layers";

--- a/pcsx2/gui-libretro/AppConfig.cpp
+++ b/pcsx2/gui-libretro/AppConfig.cpp
@@ -1209,7 +1209,7 @@ static void LoadVmSettings()
 	g_Conf->EmuOptions.LoadSave( vmloader );
 	g_Conf->EmuOptions.GS.LimitScalar = g_Conf->Framerate.NominalScalar;
 
-	g_Conf->EnablePresets = option_value(BOOL_PCSX2_OPT_ENABLE_SPEEDHACKS, KeyOptionBool::return_type);
+	g_Conf->EnablePresets = true;
 	g_Conf->PresetIndex = option_value(INT_PCSX2_OPT_SPEEDHACKS_PRESET, KeyOptionInt::return_type);
 	
 

--- a/plugins/GSdx/GS.cpp
+++ b/plugins/GSdx/GS.cpp
@@ -207,9 +207,7 @@ static int _GSopen(void** dsp, const char* title, GSRendererType renderer, int t
 			renderer = GSUtil::GetBestRenderer();
 #endif
 	}
-#ifdef __LIBRETRO__
-	threads = option_value(INT_PCSX2_OPT_RENDERER_THREADS, KeyOptionInt::return_type);
-#endif
+
 	if(threads == -1)
 	{
 		threads = theApp.GetConfigI("extrathreads");

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -120,6 +120,9 @@ void GSRendererHW::UpdateRendererOptions()
 	m_userhacks_round_sprite_offset = option_value(INT_PCSX2_OPT_USERHACK_ROUND_SPRITE, KeyOptionInt::return_type);
 	m_userhacks_wildhack = option_value(BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET, KeyOptionBool::return_type);
 	m_userhacks_ts_half_bottom = option_value(INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX, KeyOptionInt::return_type);
+	m_userhacks_auto_flush = option_value(BOOL_PCSX2_OPT_USERHACK_AUTO_FLUSH, KeyOptionBool::return_type);
+	theApp.SetConfig("UserHacks_AutoFlush", m_userhacks_auto_flush);
+	theApp.SetConfig("UserHacks", true);
 	
 	theApp.SetConfig("MaxAnisotropy", option_value(INT_PCSX2_OPT_ANISOTROPIC_FILTER, KeyOptionInt::return_type));
 	m_fxaa = option_value(INT_PCSX2_OPT_FXAA, KeyOptionInt::return_type);


### PR DESCRIPTION
Summary of changes:

- Removed 'Null' renderer option 
- Removed 'Software' renderer option and 'Software Rendered Threads' option. Reason: software rendering is not yet supported by the core. These can be reintroduced when the core has software rendering support. Until then, these options just cause confusion
- Removed 'Enable SpeedHacks' option. Reason: it's unnecessary and misleading. Prior to this PR, turning this option off does _not_ actually disable speed hacks as advertised. It actually sets the preset to 'Safe'. Ironically, the only way to truly disable speed hacks within the core options menu was to turn 'Enable SpeedHacks' _on_ and set the preset to 'Safest - No Hacks'. Given that the preset menu lets you turn off speed hacks anyway, there's no reason to have a separate toggle for this
- Gave a more detailed description of the 'Speed Hacks Preset' option
- Specified that the cheats directory is 'system/pcsx2/cheats' rather than just 'cheats'
- Fixed some typos/inconsistencies/inaccuracies in the options menu, e.g. "Considerably increases games boot time" was removed from the description of 'Enable Widescreen Patches' since that issue was fixed by #47
- Added the 'Hack: Auto Flush' option, addressing #57. It currently requires a content restart to take effect