### PR TITLE
VU-related backports

### DIFF
--- a/pcsx2/COP2.cpp
+++ b/pcsx2/COP2.cpp
@@ -22,8 +22,8 @@
 
 using namespace R5900;
 using namespace R5900::Interpreter;
-//#define CP2COND (((VU0.VI[REG_VPU_STAT].US[0] >> 8) & 1))
-#define CP2COND (vif1Regs.stat.VEW)
+#define CP2COND (((VU0.VI[REG_VPU_STAT].US[0] >> 8) & 1))
+//#define CP2COND (vif1Regs.stat.VEW)
 
 //Run the FINISH either side of the VCALL's as we have no control over it past here.
 void VCALLMS() {

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -406,7 +406,8 @@ struct Pcsx2Config
 				IntcStat		:1,		// tells Pcsx2 to fast-forward through intc_stat waits.
 				WaitLoop		:1,		// enables constant loop detection and fast-forwarding
 				vuFlagHack		:1,		// microVU specific flag hack
-				vuThread        :1;		// Enable Threaded VU1
+				vuThread : 1,		// Enable Threaded VU1
+				vu1Instant : 1;		// Enable Instant VU1 (Without MTVU only)
 		BITFIELD_END
 
 		s8	EECycleRate;		// EE cycle rate selector (1.0, 1.5, 2.0)
@@ -540,6 +541,7 @@ TraceLogFilters&				SetTraceConfig();
 // ------------ CPU / Recompiler Options ---------------
 
 #define THREAD_VU1					(EmuConfig.Cpu.Recompiler.UseMicroVU1 && EmuConfig.Speedhacks.vuThread)
+#define INSTANT_VU1					(EmuConfig.Speedhacks.vu1Instant)
 #define CHECK_MICROVU0				(EmuConfig.Cpu.Recompiler.UseMicroVU0)
 #define CHECK_MICROVU1				(EmuConfig.Cpu.Recompiler.UseMicroVU1)
 #define CHECK_EEREC					(EmuConfig.Cpu.Recompiler.EnableEE && GetCpuProviders().IsRecAvailable_EE())

--- a/pcsx2/Dmac.h
+++ b/pcsx2/Dmac.h
@@ -161,8 +161,7 @@ union tDMA_SADR {
 
 union tDMA_QWC {
 	struct {
-		u16 QWC;
-		u16 _unused;
+		u32 QWC;
 	};
 	u32 _u32;
 
@@ -178,7 +177,7 @@ struct DMACh {
 	u32 _null0[3];
 	u32 madr;
 	u32 _null1[3];
-	u16 qwc; u16 pad;
+	u32 qwc;
 	u32 _null2[3];
 	u32 tadr;
 	u32 _null3[3];

--- a/pcsx2/FiFo.cpp
+++ b/pcsx2/FiFo.cpp
@@ -108,8 +108,6 @@ void __fastcall WriteFIFO_VIF1(const mem128_t *value)
 		DevCon.Warning("Offset on VIF1 FIFO start!");
 	}
 
-	vif1ch.qwc += 1;
-
 	bool ret = VIF1transfer((u32*)value, 4);
 
 	if (vif1.cmd) {

--- a/pcsx2/Gif.cpp
+++ b/pcsx2/Gif.cpp
@@ -392,7 +392,7 @@ void GIFdma()
 			if (ptag == NULL) return;
 			//DevCon.Warning("GIF Reading Tag MSK = %x", vif1Regs.mskpath3);
 			GIF_LOG("gifdmaChain %8.8x_%8.8x size=%d, id=%d, addr=%lx tadr=%lx", ptag[1]._u32, ptag[0]._u32, gifch.qwc, ptag->ID, gifch.madr, gifch.tadr);
-			if (!CHECK_GIFFIFOHACK)gifRegs.stat.FQC = std::min((u16)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
+			if (!CHECK_GIFFIFOHACK)gifRegs.stat.FQC = std::min((u32)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
 			if (dmacRegs.ctrl.STD == STD_GIF)
 			{
 				// there are still bugs, need to also check if gifch.madr +16*qwc >= stadr, if not, stall
@@ -420,7 +420,7 @@ void GIFdma()
 
 
 		if (!CHECK_GIFFIFOHACK) {
-			gifRegs.stat.FQC = std::min((u16)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
+			gifRegs.stat.FQC = std::min((u32)0x10, gifch.qwc);// FQC=31, hack ;) (for values of 31 that equal 16) [ used to be 0xE00; // APATH=3]
 			clearFIFOstuff(true);
 		}
 
@@ -470,7 +470,7 @@ void dmaGIF()
 	gifInterrupt();
 }
 
-static u16 QWCinGIFMFIFO(u32 DrainADDR)
+static u32 QWCinGIFMFIFO(u32 DrainADDR)
 {
 	u32 ret;
 
@@ -495,7 +495,7 @@ static u16 QWCinGIFMFIFO(u32 DrainADDR)
 
 static __fi bool mfifoGIFrbTransfer()
 {
-	u16 qwc = std::min(QWCinGIFMFIFO(gifch.madr), gifch.qwc);
+	u32 qwc = std::min(QWCinGIFMFIFO(gifch.madr), gifch.qwc);
 	if (qwc == 0) {
 		DevCon.Warning("GIF FIFO EMPTY before transfer (how?)");
 	}

--- a/pcsx2/Gif_Unit.cpp
+++ b/pcsx2/Gif_Unit.cpp
@@ -24,23 +24,37 @@
 Gif_Unit gifUnit;
 
 // Returns true on stalling SIGNAL
-bool Gif_HandlerAD(u8* pMem) {
-	u32  reg  = pMem[8];
+bool Gif_HandlerAD(u8* pMem)
+{
+	u32 reg = pMem[8];
 	u32* data = (u32*)pMem;
-	if (reg == 0x50) {
+	if (reg == 0x50)
+	{
 		vif1.BITBLTBUF._u64 = *(u64*)pMem;
 	}
-	else if (reg == 0x52) {
+	else if (reg == 0x52)
+	{
 		vif1.TRXREG._u64 = *(u64*)pMem;
 	}
-	else if (reg == 0x53) { // TRXDIR
-		if ((pMem[0] & 3) == 1) { // local -> host
+	else if (reg == 0x53)
+	{ // TRXDIR
+		if ((pMem[0] & 3) == 1)
+		{                // local -> host
 			u8 bpp = 32; // Onimusha does TRXDIR without BLTDIVIDE first, assume 32bit
-			switch(vif1.BITBLTBUF.SPSM & 7) {
-				case 0: bpp = 32; break;
-				case 1: bpp = 24; break;
-				case 2: bpp = 16; break;
-				case 3: bpp = 8;  break;
+			switch (vif1.BITBLTBUF.SPSM & 7)
+			{
+				case 0:
+					bpp = 32;
+					break;
+				case 1:
+					bpp = 24;
+					break;
+				case 2:
+					bpp = 16;
+					break;
+				case 3:
+					bpp = 8;
+					break;
 				default: // 4 is 4 bit but this is forbidden
 					Console.Error("Illegal format for GS upload: SPSM=0%02o", vif1.BITBLTBUF.SPSM);
 					break;
@@ -50,113 +64,213 @@ bool Gif_HandlerAD(u8* pMem) {
 			vif1.GSLastDownloadSize = vif1.TRXREG.RRW * vif1.TRXREG.RRH * bpp >> 7;
 		}
 	}
-	else if (reg == 0x60) { // SIGNAL
-		if (CSRreg.SIGNAL) { // Time to ignore all subsequent drawing operations.
+	else if (reg == 0x60)
+	{ // SIGNAL
+		if (CSRreg.SIGNAL)
+		{ // Time to ignore all subsequent drawing operations.
 			GUNIT_WARN(Color_Orange, "GIF Handler - Stalling SIGNAL");
-			if(!gifUnit.gsSIGNAL.queued) {
-				gifUnit.gsSIGNAL.queued  = true;
+			if (!gifUnit.gsSIGNAL.queued)
+			{
+				gifUnit.gsSIGNAL.queued = true;
 				gifUnit.gsSIGNAL.data[0] = data[0];
 				gifUnit.gsSIGNAL.data[1] = data[1];
 				return true; // Stalling SIGNAL
 			}
 		}
-		else {
+		else 
+		{
 			GUNIT_WARN("GIF Handler - SIGNAL");
-			GSSIGLBLID.SIGID = (GSSIGLBLID.SIGID&~data[1])|(data[0]&data[1]);
-			if (!GSIMR.SIGMSK) gsIrq();
+			GSSIGLBLID.SIGID = (GSSIGLBLID.SIGID & ~data[1]) | (data[0] & data[1]);
+			if (!GSIMR.SIGMSK)
+				gsIrq();
 			CSRreg.SIGNAL = true;
 		}
 	}
-	else if (reg == 0x61) { // FINISH
+	else if (reg == 0x61)
+	{ // FINISH
 		GUNIT_WARN("GIF Handler - FINISH");
 		CSRreg.FINISH = true;
 	}
-	else if (reg == 0x62) { // LABEL
+	else if (reg == 0x62)
+	{ // LABEL
 		GUNIT_WARN("GIF Handler - LABEL");
-		GSSIGLBLID.LBLID = (GSSIGLBLID.LBLID&~data[1])|(data[0]&data[1]);
+		GSSIGLBLID.LBLID = (GSSIGLBLID.LBLID & ~data[1]) | (data[0] & data[1]);
 	}
-	else if (reg >= 0x63 && reg != 0x7f) {
+	else if (reg >= 0x63 && reg != 0x7f)
+	{
 		//DevCon.Warning("GIF Handler - Write to unknown register! [reg=%x]", reg);
 	}
 	return false;
 }
 
-// Returns true if pcsx2 needed to process the packet...
-bool Gif_HandlerAD_Debug(u8* pMem) {
-	u32   reg = pMem[8];
-	if   (reg == 0x50) { Console.Error("GIF Handler Debug - BITBLTBUF"); return 1; }
-	else if (reg == 0x52) { Console.Error("GIF Handler Debug - TRXREG");    return 1; }
-	else if (reg == 0x53) { Console.Error("GIF Handler Debug - TRXDIR");    return 1; }
-	else if (reg == 0x60) { Console.Error("GIF Handler Debug - SIGNAL");    return 1; }
-	else if (reg == 0x61) { Console.Error("GIF Handler Debug - FINISH");    return 1; }
-	else if (reg == 0x62) { Console.Error("GIF Handler Debug - LABEL");     return 1; }
-	else if (reg >= 0x63 && reg != 0x7f) {
+bool Gif_HandlerAD_MTVU(u8* pMem)
+{
+	u32 reg = pMem[8];
+	u32* data = (u32*)pMem;
+
+	if (reg == 0x50)
+	{
+		Console.Error("GIF Handler Debug - BITBLTBUF");
+		return 1;
+	} 	
+	else if (reg == 0x52)
+	{
+		Console.Error("GIF Handler Debug - TRXREG");
+		return 1;
+	} 	
+	else if (reg == 0x53)
+	{
+		Console.Error("GIF Handler Debug - TRXDIR");
+		return 1;
+	} 	
+	else if (reg == 0x60)
+	{ // SIGNAL
+
+		if (CSRreg.SIGNAL)
+		{ // Time to ignore all subsequent drawing operations.
+			Console.Error("GIF Handler MTVU - Double SIGNAL Not Handled");
+			return 1;
+		} 		
+		else
+		{
+			GUNIT_WARN("GIF Handler - SIGNAL");
+			vu1Thread.gsSignal = ((u64)data[1] << 32) | data[0];
+			vu1Thread.gsSignalCnt++;
+		}
+	} 	
+	else if (reg == 0x61)
+	{ // FINISH
+		GUNIT_WARN("GIF Handler - FINISH");
+		vu1Thread.gsFinish = 1;
+	} 	
+	else if (reg == 0x62)
+	{ // LABEL
+		GUNIT_WARN("GIF Handler - LABEL");
+		vu1Thread.gsLabel = ((u64)data[1] << 32) | data[0];
+		vu1Thread.gsLabelCnt++;
+	} 	
+	else if (reg >= 0x63 && reg != 0x7f)
+	{
 		DevCon.Warning("GIF Handler Debug - Write to unknown register! [reg=%x]", reg);
 	}
 	return 0;
 }
 
-void Gif_FinishIRQ() {
-	if (CSRreg.FINISH && !GSIMR.FINISHMSK && !gifUnit.gsFINISH.gsFINISHFired) {
+// Returns true if pcsx2 needed to process the packet...
+bool Gif_HandlerAD_Debug(u8* pMem)
+{
+	u32 reg = pMem[8];
+	if (reg == 0x50)
+	{
+		Console.Error("GIF Handler Debug - BITBLTBUF");
+		return 1;
+	} 	
+	else if (reg == 0x52)
+	{
+		Console.Error("GIF Handler Debug - TRXREG");
+		return 1;
+	} 	
+	else if (reg == 0x53)
+	{
+		Console.Error("GIF Handler Debug - TRXDIR");
+		return 1;
+	} 	
+	else if (reg == 0x60)
+	{
+		Console.Error("GIF Handler Debug - SIGNAL");
+		return 1;
+	} 	
+	else if (reg == 0x61)
+	{
+		Console.Error("GIF Handler Debug - FINISH");
+		return 1;
+	} 	
+	else if (reg == 0x62)
+	{
+		Console.Error("GIF Handler Debug - LABEL");
+		return 1;
+	} 	
+	else if (reg >= 0x63 && reg != 0x7f)
+	{
+		DevCon.Warning("GIF Handler Debug - Write to unknown register! [reg=%x]", reg);
+	}
+	return 0;
+}
+
+void Gif_FinishIRQ()
+{
+	if (CSRreg.FINISH && !GSIMR.FINISHMSK && !gifUnit.gsFINISH.gsFINISHFired)
+	{
 		gsIrq();
 		gifUnit.gsFINISH.gsFINISHFired = true;
 	}
 }
 
 // Used in MTVU mode... MTVU will later complete a real packet
-void Gif_AddGSPacketMTVU(GS_Packet& gsPack, GIF_PATH path) {
+void Gif_AddGSPacketMTVU(GS_Packet& gsPack, GIF_PATH path)
+{
 	GetMTGS().SendSimpleGSPacket(GS_RINGTYPE_MTVU_GSPACKET, 0, 0, path);
 }
 
-void Gif_AddCompletedGSPacket(GS_Packet& gsPack, GIF_PATH path) {
+void Gif_AddCompletedGSPacket(GS_Packet& gsPack, GIF_PATH path)
+{
 	//DevCon.WriteLn("Adding Completed Gif Packet [size=%x]", gsPack.size);
-	if (COPY_GS_PACKET_TO_MTGS) {
-		GetMTGS().PrepDataPacket(path, gsPack.size/16);
-		MemCopy_WrappedDest((u128*)&gifUnit.gifPath[path].buffer[gsPack.offset], RingBuffer.m_Ring, 
-							GetMTGS().m_packet_writepos, RingBufferSize, gsPack.size/16);
+	if (COPY_GS_PACKET_TO_MTGS)
+	{
+		GetMTGS().PrepDataPacket(path, gsPack.size / 16);
+		MemCopy_WrappedDest((u128*)&gifUnit.gifPath[path].buffer[gsPack.offset], RingBuffer.m_Ring,
+			GetMTGS().m_packet_writepos, RingBufferSize, gsPack.size / 16);
 		GetMTGS().SendDataPacket();
 	}
-	else {
+	else 
+	{
 		pxAssertDev(!gsPack.readAmount, "Gif Unit - gsPack.readAmount only valid for MTVU path 1!");
 		gifUnit.gifPath[path].readAmount.fetch_add(gsPack.size);
-		GetMTGS().SendSimpleGSPacket(GS_RINGTYPE_GSPACKET,  gsPack.offset, gsPack.size, path);
+		GetMTGS().SendSimpleGSPacket(GS_RINGTYPE_GSPACKET, gsPack.offset, gsPack.size, path);
 	}
 }
 
-void Gif_AddBlankGSPacket(u32 size, GIF_PATH path) {
+void Gif_AddBlankGSPacket(u32 size, GIF_PATH path) 
+{
 	//DevCon.WriteLn("Adding Blank Gif Packet [size=%x]", size);
 	gifUnit.gifPath[path].readAmount.fetch_add(size);
 	GetMTGS().SendSimpleGSPacket(GS_RINGTYPE_GSPACKET, ~0u, size, path);
 }
 
-void Gif_MTGS_Wait(bool isMTVU) {
+void Gif_MTGS_Wait(bool isMTVU) 
+{
 	GetMTGS().WaitGS(false, true, isMTVU);
 }
 
-void SaveStateBase::gifPathFreeze(u32 path) {
+void SaveStateBase::gifPathFreeze(u32 path) 
+{
 
 	Gif_Path& gifPath = gifUnit.gifPath[path];
-	pxAssertDev(!gifPath.readAmount,           "Gif Path readAmount should be 0!");
-	pxAssertDev(!gifPath.gsPack.readAmount,     "GS Pack readAmount should be 0!");
+	pxAssertDev(!gifPath.readAmount, "Gif Path readAmount should be 0!");
+	pxAssertDev(!gifPath.gsPack.readAmount, "GS Pack readAmount should be 0!");
 	pxAssertDev(!gifPath.GetPendingGSPackets(), "MTVU GS Pack Queue should be 0!");
 
-	if (!gifPath.isMTVU()) { // FixMe: savestate freeze bug (Gust games) with MTVU enabled
-		if (IsSaving()) { // Move all the buffered data to the start of buffer
+	if (!gifPath.isMTVU())
+	{ // FixMe: savestate freeze bug (Gust games) with MTVU enabled
+		if (IsSaving())
+		{                            // Move all the buffered data to the start of buffer
 			gifPath.RealignPacket(); // May add readAmount which we need to clear on load
 		}
 	}
 	u8* bufferPtr = gifPath.buffer; // Backup current buffer ptr
 	Freeze(gifPath.mtvu.fakePackets);
-	FreezeMem(&gifPath,  sizeof(gifPath) - sizeof(gifPath.mtvu));
+	FreezeMem(&gifPath, sizeof(gifPath) - sizeof(gifPath.mtvu));
 	FreezeMem(bufferPtr, gifPath.curSize);
 	gifPath.buffer = bufferPtr;
-	if(!IsSaving()) {
-		gifPath.readAmount        = 0;
+	if (!IsSaving())
+	{
+		gifPath.readAmount = 0;
 		gifPath.gsPack.readAmount = 0;
 	}
 }
 
-void SaveStateBase::gifFreeze() {
+void SaveStateBase::gifFreeze()
+{
 	bool mtvuMode = THREAD_VU1;
 	pxAssert(vu1Thread.IsDone());
 	GetMTGS().WaitGS();
@@ -169,8 +283,10 @@ void SaveStateBase::gifFreeze() {
 	gifPathFreeze(GIF_PATH_1);
 	gifPathFreeze(GIF_PATH_2);
 	gifPathFreeze(GIF_PATH_3);
-	if (!IsSaving()) {
-		if (mtvuMode != THREAD_VU1) {
+	if (!IsSaving())
+	{
+		if (mtvuMode != THREAD_VU1)
+		{
 			DevCon.Warning("gifUnit: MTVU Mode has switched between save/load state");
 			// ToDo: gifUnit.SwitchMTVU(mtvuMode);
 		}

--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -20,103 +20,116 @@
 #include "Vif.h"
 #include "GS.h"
 
-// FIXME common path ?
+ // FIXME common path ?
 #include "Utilities/boost_spsc_queue.hpp"
 
 struct GS_Packet;
 extern void Gif_MTGS_Wait(bool isMTVU);
 extern void Gif_FinishIRQ();
 extern bool Gif_HandlerAD(u8* pMem);
+extern bool Gif_HandlerAD_MTVU(u8* pMem);
 extern bool Gif_HandlerAD_Debug(u8* pMem);
 extern void Gif_AddBlankGSPacket(u32 size, GIF_PATH path);
-extern void Gif_AddGSPacketMTVU     (GS_Packet& gsPack, GIF_PATH path);
+extern void Gif_AddGSPacketMTVU(GS_Packet& gsPack, GIF_PATH path);
 extern void Gif_AddCompletedGSPacket(GS_Packet& gsPack, GIF_PATH path);
 extern void Gif_ParsePacket(u8* data, u32 size, GIF_PATH path);
 extern void Gif_ParsePacket(GS_Packet& gsPack, GIF_PATH path);
 
-struct Gif_Tag {
-	struct HW_Gif_Tag {
-		u16 NLOOP	: 15;
-		u16 EOP		: 1;
-		u16 _dummy0	: 16;
-		u32 _dummy1	: 14;
-		u32 PRE		: 1;
-		u32 PRIM	: 11;
-		u32 FLG		: 2;
-		u32 NREG	: 4;
+struct Gif_Tag
+{
+	struct HW_Gif_Tag
+	{
+		u16 NLOOP : 15;
+		u16 EOP : 1;
+		u16 _dummy0 : 16;
+		u32 _dummy1 : 14;
+		u32 PRE : 1;
+		u32 PRIM : 11;
+		u32 FLG : 2;
+		u32 NREG : 4;
 		u32 REGS[2];
 	} tag;
 
-	u32  nLoop;		// NLOOP left to process
-	u32  nRegs;		// NREG (1~16)
-	u32  nRegIdx;	// Current nReg Index (packed mode processing)
-	u32  len;		// Packet Length in Bytes (not including tag)
-	u32  cycles;    // Time needed to process packet data in ee-cycles
-	u8   regs[16];	// Regs
-	bool hasAD;		// Has an A+D Write
-	bool isValid;	// Tag is valid
-	
+	u32 nLoop;    // NLOOP left to process
+	u32 nRegs;    // NREG (1~16)
+	u32 nRegIdx;  // Current nReg Index (packed mode processing)
+	u32 len;      // Packet Length in Bytes (not including tag)
+	u32 cycles;   // Time needed to process packet data in ee-cycles
+	u8 regs[16];  // Regs
+	bool hasAD;   // Has an A+D Write
+	bool isValid; // Tag is valid
+
 	Gif_Tag() { Reset(); }
-	Gif_Tag(u8* pMem, bool analyze = false) {
-		setTag (pMem, analyze);
+	Gif_Tag(u8* pMem, bool analyze = false)
+	{
+		setTag(pMem, analyze);
 	}
 
-	void Reset()  { memzero(*this); }
-	u8   curReg() { return regs[nRegIdx&0xf]; }
+	void Reset() { memzero(*this); }
+	u8 curReg() { return regs[nRegIdx & 0xf]; }
 
-	void packedStep() {
-		if (nLoop > 0) {
+	void packedStep()
+	{
+		if (nLoop > 0)
+		{
 			nRegIdx++;
-			if (nRegIdx >= nRegs) {
+			if (nRegIdx >= nRegs)
+			{
 				nRegIdx = 0;
 				nLoop--;
 			}
 		}
 	}
 
-	void setTag(u8* pMem, bool analyze = false) {
-		tag   = *(HW_Gif_Tag*)pMem;
+	void setTag(u8* pMem, bool analyze = false)
+	{
+		tag = *(HW_Gif_Tag*)pMem;
 		nLoop = tag.NLOOP;
 		hasAD = false;
 		nRegIdx = 0;
 		isValid = 1;
 		len = 0; // avoid uninitialized compiler warning
-		switch(tag.FLG) {
-			case GIF_FLG_PACKED:
-				nRegs  = ((tag.NREG-1)&0xf) + 1;
-				len    = (nRegs * tag.NLOOP)* 16;
-				cycles = len << 1; // Packed Mode takes 2 ee-cycles
-				if (analyze) analyzeTag();
-				break;
-			case GIF_FLG_REGLIST:
-				nRegs  = ((tag.NREG-1)&0xf) + 1;
-				len    =((nRegs * tag.NLOOP + 1) >> 1) * 16;
-				cycles = len << 2; // Reg-list Mode takes 4 ee-cycles
-				break;
-			case GIF_FLG_IMAGE:
-			case GIF_FLG_IMAGE2:
-				nRegs  = 0;
-				len    = tag.NLOOP * 16;
-				cycles = len << 2; // Image Mode takes 4 ee-cycles
-				tag.FLG = GIF_FLG_IMAGE;
-				break;
+		switch (tag.FLG)
+		{
+		case GIF_FLG_PACKED:
+			nRegs = ((tag.NREG - 1) & 0xf) + 1;
+			len = (nRegs * tag.NLOOP) * 16;
+			cycles = len << 1; // Packed Mode takes 2 ee-cycles
+			if (analyze)
+				analyzeTag();
+			break;
+		case GIF_FLG_REGLIST:
+			nRegs = ((tag.NREG - 1) & 0xf) + 1;
+			len = ((nRegs * tag.NLOOP + 1) >> 1) * 16;
+			cycles = len << 2; // Reg-list Mode takes 4 ee-cycles
+			break;
+		case GIF_FLG_IMAGE:
+		case GIF_FLG_IMAGE2:
+			nRegs = 0;
+			len = tag.NLOOP * 16;
+			cycles = len << 2; // Image Mode takes 4 ee-cycles
+			tag.FLG = GIF_FLG_IMAGE;
+			break;
 			jNO_DEFAULT;
 		}
 	}
 
-	void analyzeTag() {
+	void analyzeTag()
+	{
 		hasAD = false;
 		u32 t = tag.REGS[0];
 		u32 i = 0;
 		u32 j = std::min<u32>(nRegs, 8);
-		for(; i < j; i++) {
+		for (; i < j; i++)
+		{
 			regs[i] = t & 0xf;
 			hasAD |= (regs[i] == GIF_REG_A_D);
 			t >>= 4;
 		}
 		t = tag.REGS[1];
 		j = nRegs;
-		for(; i < j; i++) {
+		for (; i < j; i++)
+		{
 			regs[i] = t & 0xf;
 			hasAD |= (regs[i] == GIF_REG_A_D);
 			t >>= 4;
@@ -124,78 +137,89 @@ struct Gif_Tag {
 	}
 };
 
-struct GS_Packet {
+struct GS_Packet
+{
 	// PERF note: this struct is copied various time in hot path. Don't add
 	// new field
 
-	u32  offset;     // Path buffer offset for start of packet
-	u32  size;	     // Full size of GS-Packet
-	s32  cycles;     // EE Cycles taken to process this GS packet
-	s32  readAmount; // Dummy read-amount data needed for proper buffer calculations
-	GS_Packet()  { Reset(); }
+	u32 offset;     // Path buffer offset for start of packet
+	u32 size;       // Full size of GS-Packet
+	s32 cycles;     // EE Cycles taken to process this GS packet
+	s32 readAmount; // Dummy read-amount data needed for proper buffer calculations
+	GS_Packet() { Reset(); }
 	void Reset() { memzero(*this); }
 };
 
-struct GS_SIGNAL {
-	u32  data[2];
+struct GS_SIGNAL
+{
+	u32 data[2];
 	bool queued;
 	void Reset() { memzero(*this); }
 };
 
-struct GS_FINISH {
+struct GS_FINISH
+{
 	bool gsFINISHFired;
 
 	void Reset() { memzero(*this); }
 };
 
-static __fi void incTag(u32& offset, u32& size, u32 incAmount) {
-	size   += incAmount;
+static __fi void incTag(u32& offset, u32& size, u32 incAmount)
+{
+	size += incAmount;
 	offset += incAmount;
 }
 
-struct Gif_Path_MTVU {
-	u32   fakePackets; // Fake packets pending to be sent to MTGS
+struct Gif_Path_MTVU
+{
+	u32 fakePackets; // Fake packets pending to be sent to MTGS
 	GS_Packet fakePacket;
 	// Set a size based on MTGS but keep a factor 2 to avoid too waste to much
 	// memory overhead. Note the struct is instantied 3 times (for each gif
 	// path)
 	ringbuffer_base<GS_Packet, RingBufferSize / 2> gsPackQueue;
 	Gif_Path_MTVU() { Reset(); }
-	void Reset()    { fakePackets = 0;
+	void Reset()
+	{
+		fakePackets = 0;
 		gsPackQueue.reset();
 		fakePacket.Reset();
-		fakePacket.size =~0u; // Used to indicate that its a fake packet
+		fakePacket.size = ~0u; // Used to indicate that its a fake packet
 	}
 };
 
-struct Gif_Path {
+struct Gif_Path
+{
 	std::atomic<int> readAmount; // Amount of data MTGS still needs to read
-	u8* buffer;		  // Path packet buffer
-	u32 buffSize;	  // Full size of buffer
-	u32 buffLimit;	  // Cut off limit to wrap around
-	u32 curSize;	  // Used buffer in bytes
-	u32 curOffset;	  // Offset of current gifTag
-	u32 dmaRewind;    // Used by path3 when only part of a DMA chain is used
-	Gif_Tag   gifTag; // Current GS Primitive tag
-	GS_Packet gsPack; // Current GS Packet info
-	GIF_PATH  idx;	  // Gif Path Index
-	GIF_PATH_STATE state; // Path State
-	Gif_Path_MTVU  mtvu;  // Must be last for saved states
+	u8* buffer;                  // Path packet buffer
+	u32 buffSize;                // Full size of buffer
+	u32 buffLimit;               // Cut off limit to wrap around
+	u32 curSize;                 // Used buffer in bytes
+	u32 curOffset;               // Offset of current gifTag
+	u32 dmaRewind;               // Used by path3 when only part of a DMA chain is used
+	Gif_Tag gifTag;              // Current GS Primitive tag
+	GS_Packet gsPack;            // Current GS Packet info
+	GIF_PATH idx;                // Gif Path Index
+	GIF_PATH_STATE state;        // Path State
+	Gif_Path_MTVU mtvu;          // Must be last for saved states
 
-	Gif_Path()  { Reset(); }
+	Gif_Path() { Reset(); }
 	~Gif_Path() { _aligned_free(buffer); }
 
-	void Init(GIF_PATH _idx, u32 _buffSize, u32 _buffSafeZone) {
-		idx       = _idx;
-		buffSize  = _buffSize;
+	void Init(GIF_PATH _idx, u32 _buffSize, u32 _buffSafeZone)
+	{
+		idx = _idx;
+		buffSize = _buffSize;
 		buffLimit = _buffSize - _buffSafeZone;
-		buffer    = (u8*)_aligned_malloc(buffSize, 16);
+		buffer = (u8*)_aligned_malloc(buffSize, 16);
 		Reset();
 	}
 
-	void Reset(bool softReset = false) {
+	void Reset(bool softReset = false)
+	{
 		state = GIF_PATH_IDLE;
-		if (softReset) {
+		if (softReset)
+		{
 			if (!isMTVU()) // MTVU Freaks out if you try to reset it, so let's just let it transfer
 			{
 				GUNIT_WARN("Gif Path %d - Soft Reset", idx + 1);
@@ -211,82 +235,104 @@ struct Gif_Path {
 		gsPack.Reset();
 	}
 
-	bool isMTVU() const           { return !idx && THREAD_VU1; }
-	s32 getReadAmount()           { return readAmount.load(std::memory_order_acquire) + gsPack.readAmount; }
+	bool isMTVU() const { return !idx && THREAD_VU1; }
+	s32 getReadAmount() { return readAmount.load(std::memory_order_acquire) + gsPack.readAmount; }
 	bool hasDataRemaining() const { return curOffset < curSize; }
-	bool isDone() const           { return isMTVU() ? !mtvu.fakePackets : (!hasDataRemaining() && (state == GIF_PATH_IDLE || state == GIF_PATH_WAIT)); }
+	bool isDone() const { return isMTVU() ? !mtvu.fakePackets : (!hasDataRemaining() && (state == GIF_PATH_IDLE || state == GIF_PATH_WAIT)); }
 
 	// Waits on the MTGS to process gs packets
-	void mtgsReadWait() {
-		if (IsDevBuild) {
-			DevCon.WriteLn(Color_Red,   "Gif Path[%d] - MTGS Wait! [r=0x%x]", idx+1, getReadAmount());
+	void mtgsReadWait()
+	{
+		if (IsDevBuild)
+		{
+			DevCon.WriteLn(Color_Red, "Gif Path[%d] - MTGS Wait! [r=0x%x]", idx + 1, getReadAmount());
 			Gif_MTGS_Wait(isMTVU());
-			DevCon.WriteLn(Color_Green, "Gif Path[%d] - MTGS Wait! [r=0x%x]", idx+1, getReadAmount());
+			DevCon.WriteLn(Color_Green, "Gif Path[%d] - MTGS Wait! [r=0x%x]", idx + 1, getReadAmount());
 			return;
 		}
 		Gif_MTGS_Wait(isMTVU());
 	}
 
 	// Moves packet data to start of buffer
-	void RealignPacket() {
+	void RealignPacket()
+	{
 		GUNIT_LOG("Path Buffer: Realigning packet!");
-		s32 offset    = curOffset - gsPack.size;
-		s32 sizeToAdd = curSize   - offset;
+		s32 offset = curOffset - gsPack.size;
+		s32 sizeToAdd = curSize - offset;
 		s32 intersect = sizeToAdd - offset;
-		if (intersect < 0) intersect = 0;
-		for(;;) {
-			s32 frontFree  = offset - getReadAmount();
-			if (frontFree >= sizeToAdd - intersect) break;
+		if (intersect < 0)
+			intersect = 0;
+		for (;;)
+		{
+			s32 frontFree = offset - getReadAmount();
+			if (frontFree >= sizeToAdd - intersect)
+				break;
 			mtgsReadWait();
 		}
-		if (offset < (s32)buffLimit) { // Needed for correct readAmount values
-			if (isMTVU()) gsPack.readAmount += buffLimit - offset;
-			else Gif_AddBlankGSPacket(buffLimit - offset, idx);
+		if (offset < (s32)buffLimit)
+		{ // Needed for correct readAmount values
+			if (isMTVU())
+				gsPack.readAmount += buffLimit - offset;
+			else
+				Gif_AddBlankGSPacket(buffLimit - offset, idx);
 		}
 		//DevCon.WriteLn("Realign Packet [%d]", curSize - offset);
-		if (intersect) memmove(buffer, &buffer[offset], curSize - offset);
-		else       memcpy(buffer, &buffer[offset], curSize - offset);
-		curSize      -= offset;
-		curOffset     = gsPack.size;
+		if (intersect)
+			memmove(buffer, &buffer[offset], curSize - offset);
+		else
+			memcpy(buffer, &buffer[offset], curSize - offset);
+		curSize -= offset;
+		curOffset = gsPack.size;
 		gsPack.offset = 0;
 	}
 
-	void CopyGSPacketData(u8* pMem, u32 size, bool aligned = false) {	
-		if (curSize + size > buffSize) { // Move gsPack to front of buffer
+	void CopyGSPacketData(u8* pMem, u32 size, bool aligned = false)
+	{
+		if (curSize + size > buffSize)
+		{ // Move gsPack to front of buffer
 			GUNIT_LOG("CopyGSPacketData: Realigning packet!");
 			RealignPacket();
 		}
-		for(;;) {
-			s32 offset  = curOffset - gsPack.size;
-			s32 readPos = offset    - getReadAmount();
-			if (readPos >= 0) break; // MTGS is reading in back of curOffset
-			if ((s32)buffLimit + readPos > (s32)curSize + (s32)size) break; // Enough free front space
+		for (;;)
+		{
+			s32 offset = curOffset - gsPack.size;
+			s32 readPos = offset - getReadAmount();
+			if (readPos >= 0)
+				break; // MTGS is reading in back of curOffset
+			if ((s32)buffLimit + readPos > (s32)curSize + (s32)size)
+				break;      // Enough free front space
 			mtgsReadWait(); // Let MTGS run to free up buffer space
 		}
-		pxAssertDev(curSize+size<=buffSize, "Gif Path Buffer Overflow!");
-		memcpy (&buffer[curSize], pMem, size);
-		curSize     += size;
+		pxAssertDev(curSize + size <= buffSize, "Gif Path Buffer Overflow!");
+		memcpy(&buffer[curSize], pMem, size);
+		curSize += size;
 	}
 
 	// If completed a GS packet (with EOP) then set done to true
 	// MTVU: This function only should be called called on EE thread
-	GS_Packet ExecuteGSPacket(bool &done) {
-		if (mtvu.fakePackets) { // For MTVU mode...
+	GS_Packet ExecuteGSPacket(bool& done)
+	{
+		if (mtvu.fakePackets)
+		{ // For MTVU mode...
 			mtvu.fakePackets--;
 			done = true;
 			return mtvu.fakePacket;
 		}
 		pxAssert(!isMTVU());
-		for(;;) {
-			if (!gifTag.isValid) { // Need new Gif Tag
+		for (;;)
+		{
+			if (!gifTag.isValid)
+			{ // Need new Gif Tag
 				// We don't have enough data for a Gif Tag
-				if (curOffset + 16 > curSize) {
+				if (curOffset + 16 > curSize)
+				{
 					//GUNIT_LOG("Path Buffer: Not enough data for gif tag! [%d]", curSize-curOffset);
 					return gsPack;
 				}
 
 				// Move packet to start of buffer
-				if (curOffset > buffLimit) {
+				if (curOffset > buffLimit)
+				{
 					RealignPacket();
 				}
 
@@ -295,7 +341,8 @@ struct Gif_Path {
 				state = (GIF_PATH_STATE)(gifTag.tag.FLG + 1);
 
 				// We don't have enough data for a complete GS packet
-				if(!gifTag.hasAD && curOffset + 16 + gifTag.len > curSize) {
+				if (!gifTag.hasAD && curOffset + 16 + gifTag.len > curSize)
+				{
 					gifTag.isValid = false; // So next time we test again
 					return gsPack;
 				}
@@ -304,48 +351,56 @@ struct Gif_Path {
 				gsPack.cycles += 2 + gifTag.cycles; // Tag + Len ee-cycles
 			}
 
-			if (gifTag.hasAD) { // Only can be true if GIF_FLG_PACKED
+			if (gifTag.hasAD)
+			{ // Only can be true if GIF_FLG_PACKED
 				bool dblSIGNAL = false;
-				while(gifTag.nLoop && !dblSIGNAL) {
-					if (curOffset + 16 > curSize) return gsPack; // Exit Early
-					if (gifTag.curReg() == GIF_REG_A_D) {
-						if (!isMTVU()) dblSIGNAL = Gif_HandlerAD(&buffer[curOffset]);
+				while (gifTag.nLoop && !dblSIGNAL)
+				{
+					if (curOffset + 16 > curSize)
+						return gsPack; // Exit Early
+					if (gifTag.curReg() == GIF_REG_A_D)
+					{
+						if (!isMTVU())
+							dblSIGNAL = Gif_HandlerAD(&buffer[curOffset]);
 					}
 					incTag(curOffset, gsPack.size, 16); // 1 QWC
 					gifTag.packedStep();
 				}
-				if (dblSIGNAL && !(gifTag.tag.EOP && !gifTag.nLoop)) return gsPack; // Exit Early
-			}
-			else incTag(curOffset, gsPack.size, gifTag.len); // Data length
+				if (dblSIGNAL && !(gifTag.tag.EOP && !gifTag.nLoop))
+					return gsPack; // Exit Early
+			} 			
+			else
+				incTag(curOffset, gsPack.size, gifTag.len); // Data length
 
 			// Reload gif tag next loop
 			gifTag.isValid = false;
 
-			if (gifTag.tag.EOP) {
+			if (gifTag.tag.EOP)
+			{
 				GS_Packet t = gsPack;
 				done = true;
 
 				dmaRewind = 0;
-				
+
 				gsPack.Reset();
 				gsPack.offset = curOffset;
-				
+
 				//Path 3 Masking is timing sensitive, we need to simulate its length! (NFSU2/Outrun 2006)
-				
-				if((gifRegs.stat.APATH-1) == GIF_PATH_3)
+
+				if ((gifRegs.stat.APATH - 1) == GIF_PATH_3)
 				{
 					state = GIF_PATH_WAIT;
 
-					if(curSize - curOffset > 0 && (gifRegs.stat.M3R || gifRegs.stat.M3P))
+					if (curSize - curOffset > 0 && (gifRegs.stat.M3R || gifRegs.stat.M3P))
 					{
 						//Including breaking packets early (Rewind DMA to pick up where left off)
 						//but only do this when the path is masked, else we're pointlessly slowing things down.
 						dmaRewind = curSize - curOffset;
 						curSize = curOffset;
-					}	
-				}
-				else 
-					state  = GIF_PATH_IDLE;
+					}
+				} 				
+				else
+					state = GIF_PATH_IDLE;
 
 				return t; // Complete GS packet
 			}
@@ -353,46 +408,51 @@ struct Gif_Path {
 	}
 
 	// MTVU: Gets called on VU XGkicks on MTVU thread
-	void ExecuteGSPacketMTVU() {
+	void ExecuteGSPacketMTVU()
+	{
 		// Move packet to start of buffer
-		if (curOffset > buffLimit) {
+		if (curOffset > buffLimit)
+		{
 			RealignPacket();
 		}
-		if (IsDevBuild) { // We check the packet to see if it actually
-			for(;;) {     // needed to be processed by pcsx2...
-				if (curOffset + 16 > curSize) break;
-				gifTag.setTag(&buffer[curOffset], 1);
-				
-				if(!gifTag.hasAD && curOffset + 16 + gifTag.len > curSize) break;
-				incTag(curOffset, gsPack.size, 16); // Tag Size
-				
-				if (gifTag.hasAD) { // Only can be true if GIF_FLG_PACKED
-					while(gifTag.nLoop) {
-						if (curOffset + 16 > curSize) break; // Exit Early
-						if (gifTag.curReg() == GIF_REG_A_D) {
-							pxAssert(!Gif_HandlerAD_Debug(&buffer[curOffset]));
-						}
-						incTag(curOffset, gsPack.size, 16); // 1 QWC
-						gifTag.packedStep();
+		for (;;)
+		{ // needed to be processed by pcsx2...
+			if (curOffset + 16 > curSize)
+				break;
+			gifTag.setTag(&buffer[curOffset], 1);
+
+			if (!gifTag.hasAD && curOffset + 16 + gifTag.len > curSize)
+				break;
+			incTag(curOffset, gsPack.size, 16); // Tag Size
+
+			if (gifTag.hasAD)
+			{ // Only can be true if GIF_FLG_PACKED
+				while (gifTag.nLoop)
+				{
+					if (curOffset + 16 > curSize)
+						break; // Exit Early
+					if (gifTag.curReg() == GIF_REG_A_D)
+					{
+						pxAssert(!Gif_HandlerAD_MTVU(&buffer[curOffset]));
 					}
+					incTag(curOffset, gsPack.size, 16); // 1 QWC
+					gifTag.packedStep();
 				}
-				else incTag(curOffset, gsPack.size, gifTag.len); // Data length
-				if (curOffset >= curSize) break;
-				if (gifTag.tag.EOP)       break;
-			}
-			pxAssert(curOffset == curSize);
-			gifTag.isValid = false;
+			} 			
+			else
+				incTag(curOffset, gsPack.size, gifTag.len); // Data length
+			if (curOffset >= curSize)
+				break;
+			if (gifTag.tag.EOP)
+				break;
 		}
-		else {
-			// We assume every packet is a full GS Packet
-			// And we don't process anything on pcsx2 side
-			gsPack.size += curSize - curOffset;
-			curOffset    = curSize;
-		}
+		pxAssert(curOffset == curSize);
+		gifTag.isValid = false;
 	}
 
 	// MTVU: Gets called after VU1 execution on MTVU thread
-	void FinishGSPacketMTVU() {
+	void FinishGSPacketMTVU()
+	{
 		// Performance note: fetch_add atomic operation might create some stall for atomic
 		// operation in gsPack.push
 		readAmount.fetch_add(gsPack.size + gsPack.readAmount, std::memory_order_acq_rel);
@@ -404,9 +464,11 @@ struct Gif_Path {
 	}
 
 	// MTVU: Gets called by MTGS thread
-	GS_Packet GetGSPacketMTVU() {
+	GS_Packet GetGSPacketMTVU()
+	{
 		// FIXME is the error path useful ?
-		if (!mtvu.gsPackQueue.empty()) {
+		if (!mtvu.gsPackQueue.empty())
+		{
 			return mtvu.gsPackQueue.front();
 		}
 
@@ -416,32 +478,41 @@ struct Gif_Path {
 	}
 
 	// MTVU: Gets called by MTGS thread
-	void PopGSPacketMTVU() {
+	void PopGSPacketMTVU()
+	{
 		mtvu.gsPackQueue.pop();
 	}
 
 	// MTVU: Returns the amount of pending
 	// GS Packets that MTGS hasn't yet processed
-	u32 GetPendingGSPackets() {
+	u32 GetPendingGSPackets()
+	{
 		return mtvu.gsPackQueue.size();
 	}
 };
 
-struct Gif_Unit {
-	Gif_Path   gifPath[3];
-	GS_SIGNAL  gsSIGNAL; // Stalling Signal
-	GS_FINISH  gsFINISH; // Finish Signal
+struct Gif_Unit
+{
+	Gif_Path gifPath[3];
+	GS_SIGNAL gsSIGNAL; // Stalling Signal
+	GS_FINISH gsFINISH; // Finish Signal
 	tGIF_STAT& stat;
 	GIF_TRANSFER_TYPE lastTranType; // Last Transfer Type
 
-	Gif_Unit() : gsSIGNAL(), gsFINISH(), stat(gifRegs.stat), lastTranType(GIF_TRANS_INVALID) {
-		gifPath[0].Init(GIF_PATH_1, _1mb*9, _1mb  + _1kb);
-		gifPath[1].Init(GIF_PATH_2, _1mb*9, _1mb  + _1kb);
-		gifPath[2].Init(GIF_PATH_3, _1mb*9, _1mb  + _1kb);
+	Gif_Unit()
+		: gsSIGNAL()
+		, gsFINISH()
+		, stat(gifRegs.stat)
+		, lastTranType(GIF_TRANS_INVALID)
+	{
+		gifPath[0].Init(GIF_PATH_1, _1mb * 9, _1mb + _1kb);
+		gifPath[1].Init(GIF_PATH_2, _1mb * 9, _1mb + _1kb);
+		gifPath[2].Init(GIF_PATH_3, _1mb * 9, _1mb + _1kb);
 	}
 
 	// Enable softReset when resetting during game emulation
-	void Reset(bool softReset = false) {
+	void Reset(bool softReset = false)
+	{
 		GUNIT_WARN(Color_Red, "Gif Unit Reset!!! [soft=%d]", softReset);
 		ResetRegs();
 		gsSIGNAL.Reset();
@@ -449,89 +520,135 @@ struct Gif_Unit {
 		gifPath[0].Reset(softReset);
 		gifPath[1].Reset(softReset);
 		gifPath[2].Reset(softReset);
-		if(!softReset) {
+		if (!softReset)
+		{
 			lastTranType = GIF_TRANS_INVALID;
 		}
 		//If the VIF has paused waiting for PATH3, recheck it after the reset has occurred (Eragon)
-		if (vif1Regs.stat.VGW) {
+		if (vif1Regs.stat.VGW)
+		{
 			if (!(cpuRegs.interrupt & (1 << DMAC_VIF1)))
 				CPU_INT(DMAC_VIF1, 1);
 		}
 	}
 
 	// Resets Gif HW Regs
-	void ResetRegs() {
+	void ResetRegs()
+	{
 		gifRegs.stat.reset();
 		gifRegs.ctrl.reset();
 		gifRegs.mode.reset();
 	}
 
 	// Adds a finished GS Packet to the MTGS ring buffer
-	__fi void AddCompletedGSPacket(GS_Packet& gsPack, GIF_PATH path) {
-		if (gsPack.size==~0u) Gif_AddGSPacketMTVU     (gsPack, path);
-		else                  Gif_AddCompletedGSPacket(gsPack, path);
-		if (PRINT_GIF_PACKET) Gif_ParsePacket(gsPack, path);
+	__fi void AddCompletedGSPacket(GS_Packet& gsPack, GIF_PATH path)
+	{
+		if (gsPack.size == ~0u)
+			Gif_AddGSPacketMTVU(gsPack, path);
+		else
+			Gif_AddCompletedGSPacket(gsPack, path);
+		if (PRINT_GIF_PACKET)
+			Gif_ParsePacket(gsPack, path);
 	}
 
 	// Returns GS Packet Size in bytes
-	u32 GetGSPacketSize(GIF_PATH pathIdx, u8* pMem, u32 offset = 0, u32 size = ~0u) {
+	u32 GetGSPacketSize(GIF_PATH pathIdx, u8* pMem, u32 offset = 0, u32 size = ~0u)
+	{
 		u32 memMask = pathIdx ? ~0u : 0x3fffu;
 		u32 curSize = 0;
-		for(;;) {
+		for (;;)
+		{
 			Gif_Tag gifTag(&pMem[offset & memMask]);
 			incTag(offset, curSize, 16 + gifTag.len); // Tag + Data length
-			if (pathIdx == GIF_PATH_1 && curSize >= 0x4000) {
+			if (pathIdx == GIF_PATH_1 && curSize >= 0x4000)
+			{
 				DevCon.Warning("Gif Unit - GS packet size exceeded VU memory size!");
 				return 0; // Bios does this... (Fixed if you delay vu1's xgkick by 103 vu cycles)
 			}
-			if (curSize >= size) return size;
-			if (gifTag.tag.EOP)  return curSize;
+			if (curSize >= size)
+				return size;
+			if (gifTag.tag.EOP)
+				return curSize;
 		}
 	}
 
 	// Specify the transfer type you are initiating
 	// The return value is the amount of data (in bytes) that was processed
 	// If transfer cannot take place at this moment the return value is 0
-	u32 TransferGSPacketData(GIF_TRANSFER_TYPE tranType, u8* pMem, u32 size, bool aligned=false) {
+	u32 TransferGSPacketData(GIF_TRANSFER_TYPE tranType, u8* pMem, u32 size, bool aligned = false)
+	{
 
-		if (THREAD_VU1) {
+		if (THREAD_VU1)
+		{
 			Gif_Path& path1 = gifPath[GIF_PATH_1];
-			if (tranType == GIF_TRANS_XGKICK) { // This is on the MTVU thread
+			if (tranType == GIF_TRANS_XGKICK)
+			{ // This is on the MTVU thread
 				path1.CopyGSPacketData(pMem, size, aligned);
 				path1.ExecuteGSPacketMTVU();
 				return size;
 			}
-			if (tranType == GIF_TRANS_MTVU) {   // This is on the EE thread
+			if (tranType == GIF_TRANS_MTVU)
+			{ // This is on the EE thread
 				path1.mtvu.fakePackets++;
-				if (CanDoGif()) Execute(false, true);
+				if (CanDoGif())
+					Execute(false, true);
 				return 0;
 			}
 		}
 
-		GUNIT_LOG("%s - [path=%d][size=%d]", Gif_TransferStr[(tranType>>8)&0xf], (tranType&3)+1, size);
-		if (size == 0)  { GUNIT_WARN("Gif Unit - Size == 0"); return 0; }
-		if(!CanDoGif()) { GUNIT_WARN("Gif Unit - Signal or PSE Set or Dir = GS to EE"); }
+		GUNIT_LOG("%s - [path=%d][size=%d]", Gif_TransferStr[(tranType >> 8) & 0xf], (tranType & 3) + 1, size);
+		if (size == 0)
+		{
+			GUNIT_WARN("Gif Unit - Size == 0");
+			return 0;
+		}
+		if (!CanDoGif())
+		{
+			GUNIT_WARN("Gif Unit - Signal or PSE Set or Dir = GS to EE");
+		}
 		//pxAssertDev((stat.APATH==0) || checkPaths(1,1,1), "Gif Unit - APATH wasn't cleared?");
 		lastTranType = tranType;
 
-		if (tranType == GIF_TRANS_FIFO) {
-			if(!CanDoPath3()) DevCon.Warning("Gif Unit - Path 3 FIFO transfer while !CanDoPath3()");
+		if (tranType == GIF_TRANS_FIFO)
+		{
+			if (!CanDoPath3())
+				DevCon.Warning("Gif Unit - Path 3 FIFO transfer while !CanDoPath3()");
 		}
-		if (tranType == GIF_TRANS_DMA) {
-			if(!CanDoPath3())   { if (!Path3Masked()) stat.P3Q = 1; return 0; } // DMA Stall
-			//if (stat.P2Q) DevCon.WriteLn("P2Q while path 3");
+		if (tranType == GIF_TRANS_DMA)
+		{
+			if (!CanDoPath3())
+			{
+				if (!Path3Masked())
+					stat.P3Q = 1;
+				return 0;
+			} // DMA Stall
+			  //if (stat.P2Q) DevCon.WriteLn("P2Q while path 3");
 		}
-		if (tranType == GIF_TRANS_XGKICK) {
-			if(!CanDoPath1())   { stat.P1Q = 1; } // We always buffer path1 packets
+		if (tranType == GIF_TRANS_XGKICK)
+		{
+			if (!CanDoPath1())
+			{
+				stat.P1Q = 1;
+			} // We always buffer path1 packets
 		}
-		if (tranType == GIF_TRANS_DIRECT) {
-			if(!CanDoPath2())   { stat.P2Q = 1; return 0; } // Direct Stall 
+		if (tranType == GIF_TRANS_DIRECT)
+		{
+			if (!CanDoPath2())
+			{
+				stat.P2Q = 1;
+				return 0;
+			} // Direct Stall
 		}
-		if (tranType == GIF_TRANS_DIRECTHL) {
-			if(!CanDoPath2HL()) { stat.P2Q = 1; return 0; } // DirectHL Stall
+		if (tranType == GIF_TRANS_DIRECTHL)
+		{
+			if (!CanDoPath2HL())
+			{
+				stat.P2Q = 1;
+				return 0;
+			} // DirectHL Stall
 		}
 
-		gifPath[tranType&3].CopyGSPacketData(pMem, size, aligned);
+		gifPath[tranType & 3].CopyGSPacketData(pMem, size, aligned);
 		size -= Execute(tranType == GIF_TRANS_DMA, false);
 		return size;
 	}
@@ -539,15 +656,17 @@ struct Gif_Unit {
 	// Checks path activity for the given paths
 	// Returns an int with a bit enabled if the corresponding
 	// path is not finished (needs more data/processing for an EOP)
-	__fi int checkPaths(bool p1, bool p2, bool p3, bool checkQ=false) {
+	__fi int checkPaths(bool p1, bool p2, bool p3, bool checkQ = false)
+	{
 		int ret = 0;
 		ret |= (p1 && !gifPath[GIF_PATH_1].isDone()) << 0;
 		ret |= (p2 && !gifPath[GIF_PATH_2].isDone()) << 1;
 		ret |= (p3 && !gifPath[GIF_PATH_3].isDone()) << 2;
-		return ret | (checkQ ? checkQueued(p1,p2,p3) : 0);
+		return ret | (checkQ ? checkQueued(p1, p2, p3) : 0);
 	}
 
-	__fi int checkQueued(bool p1, bool p2, bool p3) {
+	__fi int checkQueued(bool p1, bool p2, bool p3)
+	{
 		int ret = 0;
 		ret |= (p1 && stat.P1Q) << 0;
 		ret |= (p2 && stat.P2Q) << 1;
@@ -558,45 +677,59 @@ struct Gif_Unit {
 	// Send processed GS Primitive(s) to the MTGS thread
 	// Note: Only does so if current path fully completed all
 	// of its given gs primitives (but didn't upload them yet)
-	void FlushToMTGS() {
-		if (!stat.APATH) return;
-		Gif_Path& path = gifPath[stat.APATH-1];
-		if (path.gsPack.size && !path.gifTag.isValid) {
-			AddCompletedGSPacket(path.gsPack, (GIF_PATH)(stat.APATH-1));
+	void FlushToMTGS()
+	{
+		if (!stat.APATH)
+			return;
+		Gif_Path& path = gifPath[stat.APATH - 1];
+		if (path.gsPack.size && !path.gifTag.isValid)
+		{
+			AddCompletedGSPacket(path.gsPack, (GIF_PATH)(stat.APATH - 1));
 			path.gsPack.offset = path.curOffset;
-			path.gsPack.size   = 0;
+			path.gsPack.size = 0;
 		}
 	}
 
 	// Processes gif packets and performs path arbitration
 	// on EOPs or on Path 3 Images when IMT is set.
-	int Execute(bool isPath3, bool isResume) {
-		if (!CanDoGif()) { DevCon.Error("Gif Unit - Signal or PSE Set or Dir = GS to EE"); return 0; }
+	int Execute(bool isPath3, bool isResume)
+	{
+		if (!CanDoGif())
+		{
+			DevCon.Error("Gif Unit - Signal or PSE Set or Dir = GS to EE");
+			return 0;
+		}
 		bool didPath3 = false;
-		int curPath = stat.APATH > 0 ? stat.APATH-1 : 0; //Init to zero if no path is already set.
+		int curPath = stat.APATH > 0 ? stat.APATH - 1 : 0; //Init to zero if no path is already set.
 		gifPath[2].dmaRewind = 0;
 		stat.OPH = 1;
-		
-		for(;;) {
-			if (stat.APATH) { // Some Transfer is happening
-				Gif_Path& path   = gifPath[stat.APATH-1];
+
+		for (;;)
+		{
+			if (stat.APATH)
+			{ // Some Transfer is happening
+				Gif_Path& path = gifPath[stat.APATH - 1];
 				bool done = false;
 				GS_Packet gsPack = path.ExecuteGSPacket(done);
-				if(!done) {
-					if (stat.APATH == 3 && CanDoP3Slice() && !gsSIGNAL.queued) {
-						if(!didPath3 && /*!Path3Masked() &&*/ checkPaths(1,1,0)) { // Path3 slicing
+				if (!done)
+				{
+					if (stat.APATH == 3 && CanDoP3Slice() && !gsSIGNAL.queued)
+					{
+						if (!didPath3 && /*!Path3Masked() &&*/ checkPaths(1, 1, 0))
+						{ // Path3 slicing
 							didPath3 = true;
 							stat.APATH = 0;
-							stat.IP3   = 1;
+							stat.IP3 = 1;
 							GUNIT_LOG(Color_Magenta, "Gif Unit - Path 3 slicing arbitration");
-							if (gsPack.size > 16) { // Packet had other tags which we already processed
+							if (gsPack.size > 16)
+							{                                                 // Packet had other tags which we already processed
 								u32 subOffset = path.gifTag.isValid ? 16 : 0; // if isValid, image-primitive not finished
-								gsPack.size  -= subOffset; // Remove the image-tag (should be last thing read)
-								AddCompletedGSPacket(gsPack, GIF_PATH_3); // Consider current packet complete
-								path.gsPack.Reset(); // Reset gs packet info
-								path.curOffset     -= subOffset;      // Start the next GS packet at the image-tag
-								path.gsPack.offset  = path.curOffset; // Set to image-tag
-								path.gifTag.isValid = false; // Reload tag next ExecuteGSPacket()
+								gsPack.size -= subOffset;                     // Remove the image-tag (should be last thing read)
+								AddCompletedGSPacket(gsPack, GIF_PATH_3);     // Consider current packet complete
+								path.gsPack.Reset();                          // Reset gs packet info
+								path.curOffset -= subOffset;                  // Start the next GS packet at the image-tag
+								path.gsPack.offset = path.curOffset;          // Set to image-tag
+								path.gifTag.isValid = false;                  // Reload tag next ExecuteGSPacket()
 								pxAssert((s32)path.curOffset >= 0);
 								pxAssert(path.state == GIF_PATH_IMAGE);
 								GUNIT_LOG(Color_Magenta, "Gif Unit - Sending path 3 sliced gs packet!");
@@ -609,29 +742,34 @@ struct Gif_Unit {
 					break; // Not finished with GS packet
 				}
 				//DevCon.WriteLn("Adding GS Packet for path %d", stat.APATH);
-				if (gifPath[curPath].state == GIF_PATH_WAIT || gifPath[curPath].state == GIF_PATH_IDLE) {
+				if (gifPath[curPath].state == GIF_PATH_WAIT || gifPath[curPath].state == GIF_PATH_IDLE)
+				{
 					AddCompletedGSPacket(gsPack, (GIF_PATH)(stat.APATH - 1));
 				}
-				
 			}
-			if (!gsSIGNAL.queued && !gifPath[0].isDone()) {
+			if (!gsSIGNAL.queued && !gifPath[0].isDone())
+			{
 				stat.APATH = 1;
 				stat.P1Q = 0;
 				curPath = 0;
-			}
-			else if (!gsSIGNAL.queued && !gifPath[1].isDone()) {
+			} 			
+			else if (!gsSIGNAL.queued && !gifPath[1].isDone())
+			{
 				stat.APATH = 2;
 				stat.P2Q = 0;
 				curPath = 1;
-			}
-			else if (!gsSIGNAL.queued && !gifPath[2].isDone() && !Path3Masked()) {
+			} 			
+			else if (!gsSIGNAL.queued && !gifPath[2].isDone() && !Path3Masked())
+			{
 				stat.APATH = 3;
 				stat.P3Q = 0;
 				stat.IP3 = 0;
 				curPath = 2;
-			}
-			else {
-				if(isResume || curPath == 0) {
+			} 			
+			else
+			{
+				if (isResume || curPath == 0)
+				{
 					stat.APATH = 0;
 					stat.OPH = 0;
 				}
@@ -642,7 +780,7 @@ struct Gif_Unit {
 		//Some loaders/Refresh Rate selectors and things dont issue "End of Packet" commands
 		//So we look and see if the end of the last tag is all there, if so, stick it in the buffer for the GS :)
 		//(Invisible Screens on Terminator 3 and Growlanser 2/3)
-		if(gifPath[curPath].curOffset == gifPath[curPath].curSize)
+		if (gifPath[curPath].curOffset == gifPath[curPath].curSize)
 		{
 			FlushToMTGS();
 		}
@@ -650,53 +788,62 @@ struct Gif_Unit {
 		Gif_FinishIRQ();
 
 		//Path3 can rewind the DMA, so we send back the amount we go back!
-		if(isPath3)
+		if (isPath3)
 			return gifPath[2].dmaRewind;
 		else
 			return 0;
 	}
 
 	// XGkick
-	bool CanDoPath1() const {
+	bool CanDoPath1() const
+	{
 		return (stat.APATH == 0 || stat.APATH == 1 || (stat.APATH == 3 && CanDoP3Slice())) && CanDoGif();
 	}
 	// Direct
-	bool CanDoPath2() const {
+	bool CanDoPath2() const
+	{
 		return (stat.APATH == 0 || stat.APATH == 2 || (stat.APATH == 3 && CanDoP3Slice())) && CanDoGif();
 	}
 	// DirectHL
-	bool CanDoPath2HL() const {
+	bool CanDoPath2HL() const
+	{
 		return (stat.APATH == 0 || stat.APATH == 2) && CanDoGif();
 	}
 	// Gif DMA
-	bool CanDoPath3() const {
-		return((stat.APATH == 0 && !Path3Masked()) || stat.APATH == 3) && CanDoGif();
+	bool CanDoPath3() const
+	{
+		return ((stat.APATH == 0 && !Path3Masked()) || stat.APATH == 3) && CanDoGif();
 	}
 
-	bool CanDoP3Slice()const { return stat.IMT == 1 && gifPath[GIF_PATH_3].state == GIF_PATH_IMAGE; }
-	bool CanDoGif() const    { return stat.PSE == 0 && stat.DIR == 0 && gsSIGNAL.queued == 0; }
+	bool CanDoP3Slice() const { return stat.IMT == 1 && gifPath[GIF_PATH_3].state == GIF_PATH_IMAGE; }
+	bool CanDoGif() const { return stat.PSE == 0 && stat.DIR == 0 && gsSIGNAL.queued == 0; }
 	//Mask stops the next packet which hasnt started from transferring
 	bool Path3Masked() const { return ((stat.M3R || stat.M3P) && (gifPath[GIF_PATH_3].state == GIF_PATH_IDLE || gifPath[GIF_PATH_3].state == GIF_PATH_WAIT)); }
 
-	void PrintInfo(bool printP1=1, bool printP2=1, bool printP3=1) {
-		u32 a = checkPaths(1,1,1), b = checkQueued(1,1,1);
+	void PrintInfo(bool printP1 = 1, bool printP2 = 1, bool printP3 = 1)
+	{
+		u32 a = checkPaths(1, 1, 1), b = checkQueued(1, 1, 1);
 		(void)a; // Don't warn about unused variable
 		(void)b;
 		GUNIT_LOG("Gif Unit - LastTransfer = %s, Paths = [%d,%d,%d], Queued = [%d,%d,%d]",
-				   Gif_TransferStr[(lastTranType>>8)&0xf],
-				   !!(a&1),!!(a&2),!!(a&4),!!(b&1),!!(b&2),!!(b&4));
+			Gif_TransferStr[(lastTranType >> 8) & 0xf],
+			!!(a & 1), !!(a & 2), !!(a & 4), !!(b & 1), !!(b & 2), !!(b & 4));
 		GUNIT_LOG("Gif Unit - [APATH = %d][Signal = %d][PSE = %d][DIR = %d]",
-			       stat.APATH, gsSIGNAL.queued, stat.PSE, stat.DIR);
+			stat.APATH, gsSIGNAL.queued, stat.PSE, stat.DIR);
 		GUNIT_LOG("Gif Unit - [CanDoGif = %d][CanDoPath3 = %d][CanDoP3Slice = %d]",
-				   CanDoGif(), CanDoPath3(), CanDoP3Slice());
-		if (printP1) PrintPathInfo(GIF_PATH_1);
-		if (printP2) PrintPathInfo(GIF_PATH_2);
-		if (printP3) PrintPathInfo(GIF_PATH_3);
+			CanDoGif(), CanDoPath3(), CanDoP3Slice());
+		if (printP1)
+			PrintPathInfo(GIF_PATH_1);
+		if (printP2)
+			PrintPathInfo(GIF_PATH_2);
+		if (printP3)
+			PrintPathInfo(GIF_PATH_3);
 	}
 
-	void PrintPathInfo(GIF_PATH path) {
+	void PrintPathInfo(GIF_PATH path)
+	{
 		GUNIT_LOG("Gif Path %d - [hasData = %d][state = %d]", path,
-			       gifPath[path].hasDataRemaining(), gifPath[path].state);
+			gifPath[path].hasDataRemaining(), gifPath[path].state);
 	}
 };
 

--- a/pcsx2/IPU/IPU_Fifo.cpp
+++ b/pcsx2/IPU/IPU_Fifo.cpp
@@ -125,7 +125,8 @@ int IPU_Fifo_Output::write(const u32 *value, uint size)
 			--transsize;
 		}
 	/*} while(true);*/
-
+	if (ipu0ch.chcr.STR)
+		IPU_INT_FROM(64);
 	return origsize - size;
 }
 

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -196,7 +196,6 @@ void IPU0dma()
 {
 	if(!ipuRegs.ctrl.OFC) 
 	{
-		IPU_INT_FROM( 64 );
 		IPUProcessInterrupt();
 		return;
 	}

--- a/pcsx2/IPU/IPUdma.cpp
+++ b/pcsx2/IPU/IPUdma.cpp
@@ -219,64 +219,57 @@ void IPU0dma()
 
 	pMem = dmaGetAddr(ipu0ch.madr, true);
 
-	readsize = std::min(ipu0ch.qwc, (u16)ipuRegs.ctrl.OFC);
+	readsize = std::min(ipu0ch.qwc, (u32)ipuRegs.ctrl.OFC);
 	ipu_fifo.out.read(pMem, readsize);
 
 	ipu0ch.madr += readsize << 4;
-	ipu0ch.qwc -= readsize; // note: qwc is u16
-
+	ipu0ch.qwc -= readsize;
 	
-		if (dmacRegs.ctrl.STS == STS_fromIPU && ipu0ch.qwc == 0)   // STS == fromIPU
+	if (dmacRegs.ctrl.STS == STS_fromIPU && ipu0ch.qwc == 0)   // STS == fromIPU
+	{
+		//DevCon.Warning("fromIPU Stall Control");
+		dmacRegs.stadr.ADDR = ipu0ch.madr;
+		switch (dmacRegs.ctrl.STD)
 		{
-			//DevCon.Warning("fromIPU Stall Control");
-			dmacRegs.stadr.ADDR = ipu0ch.madr;
-			switch (dmacRegs.ctrl.STD)
-			{
-				case NO_STD:
-					break;
-				case STD_GIF: // GIF
-					//DevCon.Warning("GIFSTALL");
-					g_nDMATransfer.GIFSTALL = true;
-					break;
-				case STD_VIF1: // VIF
-					//DevCon.Warning("VIFSTALL");
-					g_nDMATransfer.VIFSTALL = true;
-					break;
-				case STD_SIF1:
+			case NO_STD:
+				break;
+			case STD_GIF: // GIF
+				//DevCon.Warning("GIFSTALL");
+				g_nDMATransfer.GIFSTALL = true;
+				break;
+			case STD_VIF1: // VIF
+				//DevCon.Warning("VIFSTALL");
+				g_nDMATransfer.VIFSTALL = true;
+				break;
+			case STD_SIF1:
 				//	DevCon.Warning("SIFSTALL");
-					g_nDMATransfer.SIFSTALL = true;
-					break;
-			}
+				g_nDMATransfer.SIFSTALL = true;
+				break;
 		}
-		//Fixme ( voodoocycles ):
-		//This was IPU_INT_FROM(readsize*BIAS );
-		//This broke vids in Digital Devil Saga
-		//Note that interrupting based on totalsize is just guessing..
+	}
+	//Fixme ( voodoocycles ):
+	//This was IPU_INT_FROM(readsize*BIAS );
+	//This broke vids in Digital Devil Saga
+	//Note that interrupting based on totalsize is just guessing..
 	
 	IPU_INT_FROM( readsize * BIAS );
-	if(ipuRegs.ctrl.IFC > 0) IPUProcessInterrupt();
+	if (ipuRegs.ctrl.IFC > 0) { IPUProcessInterrupt(); }
 
 	//return readsize;
 }
 
 __fi void dmaIPU0() // fromIPU
 {
-	if (ipu0ch.pad != 0)
-	{
-		// Note: pad is the padding right above qwc, so we're testing whether qwc
-		// has overflowed into pad.
-	    DevCon.Warning(L"IPU0dma's upper 16 bits set to %x", ipu0ch.pad);
-		ipu0ch.qwc = ipu0ch.pad = 0;
-		//If we are going to clear down IPU0, we should end it too. Going to test this scenario on the PS2 mind - Refraction
-		ipu0ch.chcr.STR = false;
-		hwDmacIrq(DMAC_FROM_IPU);
-	}
 	//if (dmacRegs.ctrl.STS == STS_fromIPU) DevCon.Warning("DMA Stall enabled on IPU0");
 
 	if (dmacRegs.ctrl.STS == STS_fromIPU)   // STS == fromIPU - Initial settings
 		dmacRegs.stadr.ADDR = ipu0ch.madr;
 
-	IPU_INT_FROM( 64 );
+	// Note: This should probably be a very small value, however anything lower than this will break Mana Khemia
+	// This is because the game sends bad DMA information, starts an IDEC, then sets it to the correct values
+	// but because our IPU is too quick, it messes up the sync between the DMA and IPU.
+	// So this will do until (if) we sort the timing out of IPU, shouldn't cause any problems for games for now.
+	IPU_INT_FROM(160);
 
 
 	
@@ -285,31 +278,6 @@ __fi void dmaIPU0() // fromIPU
 __fi void dmaIPU1() // toIPU
 {
 	IPU_LOG("IPU1DMAStart QWC %x, MADR %x, CHCR %x, TADR %x", ipu1ch.qwc, ipu1ch.madr, ipu1ch.chcr._u32, ipu1ch.tadr);
-
-	if (ipu1ch.pad != 0)
-	{
-		// Note: pad is the padding right above qwc, so we're testing whether qwc
-		// has overflowed into pad.
-	    DevCon.Warning(L"IPU1dma's upper 16 bits set to %x\n", ipu1ch.pad);
-		ipu1ch.qwc = ipu1ch.pad = 0;
-		// If we are going to clear down IPU1, we should end it too.
-		// Going to test this scenario on the PS2 mind - Refraction
-		ipu1ch.chcr.STR = false;
-		hwDmacIrq(DMAC_TO_IPU);
-	}
-
-	if (ipu1ch.chcr.MOD == NORMAL_MODE && ipu1ch.qwc == 0) //avoids freeze when IPU1 Normal error is triggered
-	{
-		/*ipu1ch.chcr.STR = false;
-		// Hack to force stop IPU
-		ipuRegs.cmd.BUSY = 0;
-		ipuRegs.ctrl.BUSY = 0;
-		ipuRegs.topbusy = 0;
-		//
-		hwDmacIrq(DMAC_TO_IPU);*/
-		IPU_LOG("IPU1 Normal error fix");
-		ipu1ch.qwc = 1;
-	}
 
 	if (ipu1ch.chcr.MOD == CHAIN_MODE)  //Chain Mode
 	{

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -417,7 +417,7 @@ void VU_Thread::WaitVU()
 		if (IsDone())
 			break;
 		//DevCon.WriteLn("WaitVU()");
-		pxAssert(THREAD_VU1);
+		//pxAssert(THREAD_VU1);
 		KickStart();
 		std::this_thread::yield(); // Give a chance to the MTVU thread to actually start
 		ScopedLock lock(mtxBusy);
@@ -465,6 +465,7 @@ void VU_Thread::WriteMicroMem(u32 vu_micro_addr, void* data, u32 size)
 	Write(size);
 	Write(data, size);
 	CommitWritePos();
+	KickStart();
 }
 
 void VU_Thread::WriteDataMem(u32 vu_data_addr, void* data, u32 size)
@@ -476,6 +477,7 @@ void VU_Thread::WriteDataMem(u32 vu_data_addr, void* data, u32 size)
 	Write(size);
 	Write(data, size);
 	CommitWritePos();
+	KickStart();
 }
 
 void VU_Thread::WriteCol(vifStruct& _vif)

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -22,12 +22,13 @@
 __aligned16 VU_Thread vu1Thread(CpuVU1, VU1);
 
 #define MTVU_ALWAYS_KICK 0
-#define MTVU_SYNC_MODE   0
+#define MTVU_SYNC_MODE 0
 
 // Rounds up a size in bytes for size in u32's
 static __fi u32 size_u32(u32 x) { return (x + 3) >> 2; }
 
-enum MTVU_EVENT {
+enum MTVU_EVENT
+{
 	MTVU_VU_EXECUTE,     // Execute VU program
 	MTVU_VU_WRITE_MICRO, // Write to VU micro-mem
 	MTVU_VU_WRITE_DATA,  // Write to VU data-mem
@@ -43,8 +44,10 @@ static void MTVU_Unpack(void* data, VIFregisters& vifRegs)
 {
 	u16 wl = vifRegs.cycle.wl > 0 ? vifRegs.cycle.wl : 256;
 	bool isFill = vifRegs.cycle.cl < wl;
-	if (newVifDynaRec) dVifUnpack<1>((u8*)data, isFill);
-	else              _nVifUnpack(1, (u8*)data, vifRegs.mode, isFill);
+	if (newVifDynaRec)
+		dVifUnpack<1>((u8*)data, isFill);
+	else
+		_nVifUnpack(1, (u8*)data, vifRegs.mode, isFill);
 }
 
 // Called on Saving/Loading states...
@@ -52,16 +55,41 @@ void SaveStateBase::mtvuFreeze()
 {
 	FreezeTag("MTVU");
 	pxAssert(vu1Thread.IsDone());
-	if (!IsSaving()) vu1Thread.Reset();
-	for (size_t i = 0; i < 4; ++i) {
+	if (!IsSaving())
+		vu1Thread.Reset();
+	for (size_t i = 0; i < 4; ++i)
+	{
 		unsigned int v = vu1Thread.vuCycles[i].load();
 		Freeze(v);
 	}
+	u32 gsFinishInt;
+	u64 gsSignals;
+	u32 gsSignalsCnt;
+
+	gsFinishInt = vu1Thread.gsFinish.load();
+	Freeze(gsFinishInt);
+	vu1Thread.gsFinish.store(gsFinishInt);
+	gsSignals = vu1Thread.gsSignal.load();
+	Freeze(gsSignals);
+	vu1Thread.gsSignal.store(gsSignals);
+	gsSignalsCnt = vu1Thread.gsSignalCnt.load();
+	Freeze(gsSignalsCnt);
+	vu1Thread.gsSignalCnt.store(gsSignalsCnt);
+	gsSignals = vu1Thread.gsLabel.load();
+	Freeze(gsSignals);
+	vu1Thread.gsLabel.store(gsSignals);
+	gsSignalsCnt = vu1Thread.gsLabelCnt.load();
+	Freeze(gsSignalsCnt);
+	vu1Thread.gsLabelCnt.store(gsSignalsCnt);
+
 	Freeze(vu1Thread.vuCycleIdx);
+	Freeze(vu1Thread.lastLabel);
+	Freeze(vu1Thread.lastSignal);
 }
 
-VU_Thread::VU_Thread(BaseVUmicroCPU*& _vuCPU, VURegs& _vuRegs) :
-		vuCPU(_vuCPU), vuRegs(_vuRegs)
+VU_Thread::VU_Thread(BaseVUmicroCPU*& _vuCPU, VURegs& _vuRegs)
+	: vuCPU(_vuCPU)
+	, vuRegs(_vuRegs)
 {
 	m_name = L"MTVU";
 #ifndef __LIBRETRO__
@@ -71,7 +99,8 @@ VU_Thread::VU_Thread(BaseVUmicroCPU*& _vuCPU, VURegs& _vuRegs) :
 
 VU_Thread::~VU_Thread()
 {
-	try {
+	try
+	{
 		pxThread::Cancel();
 	}
 	DESTRUCTOR_CATCHALL
@@ -81,79 +110,93 @@ void VU_Thread::Reset()
 {
 	ScopedLock lock(mtxBusy);
 
-	vuCycleIdx   = 0;
-	isBusy       = false;
+	vuCycleIdx = 0;
+	lastLabel = 0;
+	lastSignal = 0;
+	isBusy = false;
 	m_ato_write_pos = 0;
-	m_write_pos     = 0;
-	m_ato_read_pos  = 0;
-	m_read_pos      = 0;
+	m_write_pos = 0;
+	m_ato_read_pos = 0;
+	m_read_pos = 0;
 	memzero(vif);
 	memzero(vifRegs);
 	for (size_t i = 0; i < 4; ++i)
 		vu1Thread.vuCycles[i] = 0;
+	vu1Thread.gsSignal = 0;
+	vu1Thread.gsLabel = 0;
 }
 
 void VU_Thread::ExecuteTaskInThread()
 {
-	PCSX2_PAGEFAULT_PROTECT {
+	PCSX2_PAGEFAULT_PROTECT
+	{
 		ExecuteRingBuffer();
-	} PCSX2_PAGEFAULT_EXCEPT;
+	}
+	PCSX2_PAGEFAULT_EXCEPT;
 }
 
 void VU_Thread::ExecuteRingBuffer()
 {
-	for(;;) {
+	for (;;)
+	{
 		semaEvent.WaitWithoutYield();
 		ScopedLockBool lock(mtxBusy, isBusy);
-		while (m_ato_read_pos.load(std::memory_order_relaxed) != GetWritePos()) {
+		while (m_ato_read_pos.load(std::memory_order_relaxed) != GetWritePos())
+		{
 			u32 tag = Read();
-			switch (tag) {
-				case MTVU_VU_EXECUTE: {
-					vuRegs.cycle = 0;
-					s32 addr     = Read();
-					vifRegs.top  = Read();
-					vifRegs.itop = Read();
+			switch (tag)
+			{
+			case MTVU_VU_EXECUTE:
+			{
+				vuRegs.cycle = 0;
+				s32 addr = Read();
+				vifRegs.top = Read();
+				vifRegs.itop = Read();
 
-					if (addr != -1) vuRegs.VI[REG_TPC].UL = addr;
-					vuCPU->SetStartPC(vuRegs.VI[REG_TPC].UL << 3);
-					vuCPU->Execute(vu1RunCycles);
-					gifUnit.gifPath[GIF_PATH_1].FinishGSPacketMTVU();
-					semaXGkick.Post(); // Tell MTGS a path1 packet is complete
-					vuCycles[vuCycleIdx].store(vuRegs.cycle, std::memory_order_release);
-					vuCycleIdx  = (vuCycleIdx + 1) & 3;
-					break;
-				}
-				case MTVU_VU_WRITE_MICRO: {
-					u32 vu_micro_addr = Read();
-					u32 size = Read();
-					vuCPU->Clear(vu_micro_addr, size);
-					Read(&vuRegs.Micro[vu_micro_addr], size);
-					break;
-				}
-				case MTVU_VU_WRITE_DATA: {
-					u32 vu_data_addr = Read();
-					u32 size = Read();
-					Read(&vuRegs.Mem[vu_data_addr], size);
-					break;
-				}
-				case MTVU_VIF_WRITE_COL:
-					Read(&vif.MaskCol, sizeof(vif.MaskCol));
-					break;
-				case MTVU_VIF_WRITE_ROW:
-					Read(&vif.MaskRow, sizeof(vif.MaskRow));
-					break;
-				case MTVU_VIF_UNPACK: {
-					u32 vif_copy_size = (uptr)&vif.StructEnd - (uptr)&vif.tag;
-					Read(&vif.tag, vif_copy_size);
-					ReadRegs(&vifRegs);
-					u32 size = Read();
-					MTVU_Unpack(&buffer[m_read_pos], vifRegs);
-					m_read_pos += size_u32(size);
-					break;
-				}
-				case MTVU_NULL_PACKET:
-					m_read_pos = 0;
-					break;
+				if (addr != -1)
+					vuRegs.VI[REG_TPC].UL = addr;
+				vuCPU->SetStartPC(vuRegs.VI[REG_TPC].UL << 3);
+				vuCPU->Execute(vu1RunCycles);
+				gifUnit.gifPath[GIF_PATH_1].FinishGSPacketMTVU();
+				semaXGkick.Post(); // Tell MTGS a path1 packet is complete
+				vuCycles[vuCycleIdx].store(vuRegs.cycle, std::memory_order_release);
+				vuCycleIdx = (vuCycleIdx + 1) & 3;
+				break;
+			}
+			case MTVU_VU_WRITE_MICRO:
+			{
+				u32 vu_micro_addr = Read();
+				u32 size = Read();
+				vuCPU->Clear(vu_micro_addr, size);
+				Read(&vuRegs.Micro[vu_micro_addr], size);
+				break;
+			}
+			case MTVU_VU_WRITE_DATA:
+			{
+				u32 vu_data_addr = Read();
+				u32 size = Read();
+				Read(&vuRegs.Mem[vu_data_addr], size);
+				break;
+			}
+			case MTVU_VIF_WRITE_COL:
+				Read(&vif.MaskCol, sizeof(vif.MaskCol));
+				break;
+			case MTVU_VIF_WRITE_ROW:
+				Read(&vif.MaskRow, sizeof(vif.MaskRow));
+				break;
+			case MTVU_VIF_UNPACK:
+			{
+				u32 vif_copy_size = (uptr)&vif.StructEnd - (uptr)&vif.tag;
+				Read(&vif.tag, vif_copy_size);
+				ReadRegs(&vifRegs);
+				u32 size = Read();
+				MTVU_Unpack(&buffer[m_read_pos], vifRegs);
+				m_read_pos += size_u32(size);
+				break;
+			}
+			case MTVU_NULL_PACKET:
+				m_read_pos = 0;
+				break;
 				jNO_DEFAULT;
 			}
 
@@ -166,16 +209,19 @@ void VU_Thread::ExecuteRingBuffer()
 // Should only be called by ReserveSpace()
 __ri void VU_Thread::WaitOnSize(s32 size)
 {
-	for(;;) {
-		s32 readPos  = GetReadPos();
-		if (readPos <= m_write_pos) break; // MTVU is reading in back of write_pos
+	for (;;)
+	{
+		s32 readPos = GetReadPos();
+		if (readPos <= m_write_pos)
+			break; // MTVU is reading in back of write_pos
 		// FIXME greg: there is a bug somewhere in the queue pointer
 		// management. It creates a deadlock/corruption in SotC intro (before
 		// the first menu). I added a 4KB safety net which seem to avoid to
 		// trigger the bug.
 		// Note: a wait lock instead of a yield also helps to avoid the bug.
-		if (readPos >  m_write_pos + size + _4kb) break; // Enough free front space
-		{ // Let MTVU run to free up buffer space
+		if (readPos > m_write_pos + size + _4kb)
+			break; // Enough free front space
+		{          // Let MTVU run to free up buffer space
 			KickStart();
 			// Locking might trigger a full flush of the ring buffer. Yield
 			// will be more aggressive, and only flush the minimal size.
@@ -191,10 +237,11 @@ __ri void VU_Thread::WaitOnSize(s32 size)
 void VU_Thread::ReserveSpace(s32 size)
 {
 	pxAssert(m_write_pos < buffer_size);
-	pxAssert(size      < buffer_size);
+	pxAssert(size < buffer_size);
 	pxAssert(size > 0);
 
-	if (m_write_pos + size > (buffer_size - 1)) {
+	if (m_write_pos + size > (buffer_size - 1))
+	{
 		WaitOnSize(1); // Size of MTVU_NULL_PACKET
 		Write(MTVU_NULL_PACKET);
 		// Reset local write pointer/position
@@ -228,8 +275,10 @@ __fi void VU_Thread::CommitWritePos()
 {
 	m_ato_write_pos.store(m_write_pos, std::memory_order_release);
 
-	if (MTVU_ALWAYS_KICK) KickStart();
-	if (MTVU_SYNC_MODE)   WaitVU();
+	if (MTVU_ALWAYS_KICK)
+		KickStart();
+	if (MTVU_SYNC_MODE)
+		WaitVU();
 }
 
 __fi void VU_Thread::CommitReadPos()
@@ -291,15 +340,68 @@ __fi void VU_Thread::WriteRegs(VIFregisters* src)
 u32 VU_Thread::Get_vuCycles()
 {
 	return (vuCycles[0].load(std::memory_order_acquire) +
-			vuCycles[1].load(std::memory_order_acquire) +
-			vuCycles[2].load(std::memory_order_acquire) +
-			vuCycles[3].load(std::memory_order_acquire)) >> 2;
+		vuCycles[1].load(std::memory_order_acquire) +
+		vuCycles[2].load(std::memory_order_acquire) +
+		vuCycles[3].load(std::memory_order_acquire)) >>
+		2;
+}
+
+void VU_Thread::Get_GSChanges()
+{
+	u32 finishInt = gsFinish.load(std::memory_order_acquire);
+	u64 signalCnt = gsSignalCnt.load(std::memory_order_acquire);
+	u64 labelCnt = gsLabelCnt.load(std::memory_order_acquire);
+
+	if (signalCnt != lastSignal)
+	{
+		GUNIT_WARN("SIGNAL firing");
+		const u64 signal = gsSignal.load(std::memory_order_acquire);
+		const u32 signalMsk = (u32)(signal >> 32);
+		const u32 signalData = (u32)signal;
+		lastSignal = signalCnt;
+		if (CSRreg.SIGNAL)
+		{
+			GUNIT_WARN("Queue SIGNAL");
+			gifUnit.gsSIGNAL.queued = true;
+			//DevCon.Warning("Firing pending signal");
+			gifUnit.gsSIGNAL.data[0] = signalData;
+			gifUnit.gsSIGNAL.data[1] = signalMsk;
+		} 		
+		else
+		{
+			CSRreg.SIGNAL = true;
+			GSSIGLBLID.SIGID = (GSSIGLBLID.SIGID & ~signalMsk) | (signalData & signalMsk);
+
+			if (!GSIMR.SIGMSK)
+				gsIrq();
+		}
+	}
+	if (finishInt)
+	{
+		GUNIT_WARN("Finish firing");
+		CSRreg.FINISH = true;
+		gifUnit.gsFINISH.gsFINISHFired = false;
+
+		if (!gifRegs.stat.APATH)
+			Gif_FinishIRQ();
+
+		gsFinish.store(0);
+	}
+	if (labelCnt != lastLabel)
+	{
+		GUNIT_WARN("LABEL firing");
+		const u64 label = gsLabel.load(std::memory_order_acquire);
+		const u32 labelMsk = (u32)(label >> 32);
+		const u32 labelData = (u32)label;
+		lastLabel = labelCnt;
+		GSSIGLBLID.LBLID = (GSSIGLBLID.LBLID & ~labelMsk) | (labelData & labelMsk);
+	}
 }
 
 void VU_Thread::KickStart(bool forceKick)
 {
-	if ((forceKick && !semaEvent.Count())
-	|| (!isBusy.load(std::memory_order_acquire) && GetReadPos() != m_ato_write_pos.load(std::memory_order_relaxed))) semaEvent.Post();
+	if ((forceKick && !semaEvent.Count()) || (!isBusy.load(std::memory_order_acquire) && GetReadPos() != m_ato_write_pos.load(std::memory_order_relaxed)))
+		semaEvent.Post();
 }
 
 bool VU_Thread::IsDone()
@@ -310,8 +412,10 @@ bool VU_Thread::IsDone()
 void VU_Thread::WaitVU()
 {
 	MTVU_LOG("MTVU - WaitVU!");
-	for(;;) {
-		if (IsDone()) break;
+	for (;;)
+	{
+		if (IsDone())
+			break;
 		//DevCon.WriteLn("WaitVU()");
 		pxAssert(THREAD_VU1);
 		KickStart();
@@ -323,6 +427,7 @@ void VU_Thread::WaitVU()
 void VU_Thread::ExecuteVU(u32 vu_addr, u32 vif_top, u32 vif_itop)
 {
 	MTVU_LOG("MTVU - ExecuteVU!");
+	Get_GSChanges(); // Clear any pending interrupts
 	ReserveSpace(4);
 	Write(MTVU_VU_EXECUTE);
 	Write(vu_addr);
@@ -334,6 +439,7 @@ void VU_Thread::ExecuteVU(u32 vu_addr, u32 vif_top, u32 vif_itop)
 	u32 cycles = std::min(Get_vuCycles(), 3000u);
 	cpuRegs.cycle += cycles * EmuConfig.Speedhacks.EECycleSkip;
 	VU0.cycle += cycles * EmuConfig.Speedhacks.EECycleSkip;
+	Get_GSChanges();
 }
 
 void VU_Thread::VifUnpack(vifStruct& _vif, VIFregisters& _vifRegs, u8* data, u32 size)

--- a/pcsx2/MTVU.cpp
+++ b/pcsx2/MTVU.cpp
@@ -115,6 +115,7 @@ void VU_Thread::ExecuteRingBuffer()
 					vifRegs.itop = Read();
 
 					if (addr != -1) vuRegs.VI[REG_TPC].UL = addr;
+					vuCPU->SetStartPC(vuRegs.VI[REG_TPC].UL << 3);
 					vuCPU->Execute(vu1RunCycles);
 					gifUnit.gifPath[GIF_PATH_1].FinishGSPacketMTVU();
 					semaXGkick.Post(); // Tell MTGS a path1 packet is complete

--- a/pcsx2/MTVU.h
+++ b/pcsx2/MTVU.h
@@ -47,6 +47,13 @@ public:
 	__aligned(4) Semaphore semaXGkick;
 	__aligned(4) std::atomic<unsigned int> vuCycles[4]; // Used for VU cycle stealing hack
 	__aligned(4) u32 vuCycleIdx;  // Used for VU cycle stealing hack
+	__aligned(4) u32 lastSignal;
+	__aligned(4) u32 lastLabel;
+	__aligned(4) std::atomic<unsigned int> gsFinish; // Used for GS Signal, Finish etc
+	__aligned(4) std::atomic<u32> gsLabelCnt; // Used for GS Label command
+	__aligned(4) std::atomic<u32> gsSignalCnt; // Used for GS Signal command
+	__aligned(4) std::atomic<u64> gsLabel; // Used for GS Label command
+	__aligned(4) std::atomic<u64> gsSignal; // Used for GS Signal command
 
 	VU_Thread(BaseVUmicroCPU*& _vuCPU, VURegs& _vuRegs);
 	virtual ~VU_Thread();
@@ -61,6 +68,8 @@ public:
 
 	// Waits till MTVU is done processing
 	void WaitVU();
+
+	void Get_GSChanges();
 
 	void ExecuteVU(u32 vu_addr, u32 vif_top, u32 vif_itop);
 

--- a/pcsx2/MTVU.h
+++ b/pcsx2/MTVU.h
@@ -44,16 +44,19 @@ class VU_Thread : public pxThread {
 public:
 	__aligned16  vifStruct        vif;
 	__aligned16  VIFregisters     vifRegs;
-	__aligned(4) Semaphore semaXGkick;
-	__aligned(4) std::atomic<unsigned int> vuCycles[4]; // Used for VU cycle stealing hack
-	__aligned(4) u32 vuCycleIdx;  // Used for VU cycle stealing hack
-	__aligned(4) u32 lastSignal;
-	__aligned(4) u32 lastLabel;
-	__aligned(4) std::atomic<unsigned int> gsFinish; // Used for GS Signal, Finish etc
-	__aligned(4) std::atomic<u32> gsLabelCnt; // Used for GS Label command
-	__aligned(4) std::atomic<u32> gsSignalCnt; // Used for GS Signal command
-	__aligned(4) std::atomic<u64> gsLabel; // Used for GS Label command
-	__aligned(4) std::atomic<u64> gsSignal; // Used for GS Signal command
+	Semaphore semaXGkick;
+	std::atomic<unsigned int> vuCycles[4]; // Used for VU cycle stealing hack
+	u32 vuCycleIdx;  // Used for VU cycle stealing hack
+
+	enum InterruptFlag {
+		InterruptFlagFinish = 1 << 0,
+		InterruptFlagSignal = 1 << 1,
+		InterruptFlagLabel = 1 << 2,
+	};
+
+	std::atomic<u32> gsInterrupts; // Used for GS Signal, Finish etc
+	std::atomic<u64> gsLabel; // Used for GS Label command
+	std::atomic<u64> gsSignal; // Used for GS Signal command
 
 	VU_Thread(BaseVUmicroCPU*& _vuCPU, VURegs& _vuRegs);
 	virtual ~VU_Thread();

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -55,7 +55,7 @@ void Pcsx2Config::SpeedhackOptions::Set(SpeedhackId id, bool enabled)
 		vuFlagHack = enabled;
 		break;
 	case Speedhack_InstantVU1:
-		//vu1Instant = enabled;
+		vu1Instant = enabled;
 		break;
 		jNO_DEFAULT;
 	}
@@ -69,6 +69,7 @@ Pcsx2Config::SpeedhackOptions::SpeedhackOptions()
 	WaitLoop = true;
 	IntcStat = true;
 	vuFlagHack = true;
+	vu1Instant = true;
 }
 
 Pcsx2Config::SpeedhackOptions& Pcsx2Config::SpeedhackOptions::DisableAll()
@@ -91,7 +92,7 @@ void Pcsx2Config::SpeedhackOptions::LoadSave( IniInterface& ini )
 	IniBitBool(WaitLoop);
 	IniBitBool(vuFlagHack);
 	IniBitBool(vuThread);
-	//IniBitBool(vu1Instant);
+	IniBitBool(vu1Instant);
 }
 
 void Pcsx2Config::ProfilerOptions::LoadSave( IniInterface& ini )

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -431,7 +431,7 @@ __fi void _cpuEventTest_Shared()
 	// We're in a EventTest.  All dynarec registers are flushed
 	// so there is no need to freeze registers here.
 	CpuVU0->ExecuteBlock();
-
+	CpuVU1->ExecuteBlock();
 	// Note:  We don't update the VU1 here because it runs it's micro-programs in
 	// one shot always.  That is, when a program is executed the VU1 doesn't even
 	// bother to return until the program is completely finished.

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -134,6 +134,7 @@ struct __aligned16 VURegs {
 	// Current opcode being interpreted or recompiled (this var is used by Interps
 	// but not microVU.  Would like to have it local to their respective classes... someday)
 	u32 code;
+	u32 start_pc;
 
 	// branch/branchpc are used by interpreter only, but making them local to the interpreter
 	// classes requires considerable code refactoring.  Maybe later. >_<

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -170,10 +170,8 @@ void CTC2() {
 			}
 			break;
 		case REG_CMSAR1: // REG_CMSAR1
-			if (!(VU0.VI[REG_VPU_STAT].UL & 0x100) ) {
-				vu1ExecMicro(cpuRegs.GPR.r[_Rt_].US[0]);	// Execute VU1 Micro SubRoutine
-				vif1VUFinish();
-			}
+			vu1Finish(true);
+			vu1ExecMicro(cpuRegs.GPR.r[_Rt_].US[0]);	// Execute VU1 Micro SubRoutine
 			break;
 		default:
 			VU0.VI[_Fs_].UL = cpuRegs.GPR.r[_Rt_].UL[0];

--- a/pcsx2/VU0micro.cpp
+++ b/pcsx2/VU0micro.cpp
@@ -48,6 +48,8 @@ void __fastcall vu0ExecMicro(u32 addr) {
 	VU0.VI[REG_VPU_STAT].UL |=  0x01;
 	VU0.cycle = cpuRegs.cycle;
 	if ((s32)addr != -1) VU0.VI[REG_TPC].UL = addr;
+
+	CpuVU0->SetStartPC(VU0.VI[REG_TPC].UL << 3);
 	_vuExecMicroDebug(VU0);
 	CpuVU0->ExecuteBlock(1);
 }

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -198,6 +198,11 @@ InterpVU0::InterpVU0()
 	IsInterpreter = true;
 }
 
+void InterpVU0::SetStartPC(u32 startPC)
+{
+	VU0.start_pc = startPC;
+}
+
 void InterpVU0::Step()
 {
 	vu0Exec( &VU0 );

--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -61,7 +61,8 @@ void __fastcall vu1ExecMicro(u32 addr)
 	VU0.VI[REG_VPU_STAT].UL &= ~0xFF00;
 	VU0.VI[REG_VPU_STAT].UL |=  0x0100;
 	if ((s32)addr != -1) VU1.VI[REG_TPC].UL = addr;
-	_vuExecMicroDebug(VU1);
 
+	CpuVU1->SetStartPC(VU1.VI[REG_TPC].UL << 3);
+	_vuExecMicroDebug(VU1);
 	CpuVU1->Execute(vu1RunCycles);
 }

--- a/pcsx2/VU1micro.cpp
+++ b/pcsx2/VU1micro.cpp
@@ -35,14 +35,23 @@ void vu1ResetRegs()
 	vif1Regs.stat.VEW = false;
 }
 
-void vu1Finish() {
+void vu1Finish(bool add_cycles) {
 	if (THREAD_VU1) {
 		if (VU0.VI[REG_VPU_STAT].UL & 0x100) DevCon.Error("MTVU: VU0.VI[REG_VPU_STAT].UL & 0x100");
 		return;
 	}
-	while (VU0.VI[REG_VPU_STAT].UL & 0x100) {
+	u32 vu1cycles = VU1.cycle;
+	if (VU0.VI[REG_VPU_STAT].UL & 0x100) {
 		VUM_LOG("vu1ExecMicro > Stalling until current microprogram finishes");
 		CpuVU1->Execute(vu1RunCycles);
+	}
+	if (VU0.VI[REG_VPU_STAT].UL & 0x100) {
+		DevCon.Warning("Force Stopping VU1, ran for too long");
+		VU0.VI[REG_VPU_STAT].UL &= ~0x100;
+	}
+	if (add_cycles)
+	{
+		cpuRegs.cycle += VU1.cycle - vu1cycles;
 	}
 }
 
@@ -54,7 +63,7 @@ void __fastcall vu1ExecMicro(u32 addr)
 		return;
 	}
 	static int count = 0;
-	vu1Finish();
+	vu1Finish(false);
 
 	VUM_LOG("vu1ExecMicro %x (count=%d)", addr, count++);
 	VU1.cycle = cpuRegs.cycle;
@@ -64,5 +73,8 @@ void __fastcall vu1ExecMicro(u32 addr)
 
 	CpuVU1->SetStartPC(VU1.VI[REG_TPC].UL << 3);
 	_vuExecMicroDebug(VU1);
-	CpuVU1->Execute(vu1RunCycles);
+	if (!INSTANT_VU1)
+		CpuVU1->ExecuteBlock(1);
+	else
+		CpuVU1->Execute(vu1RunCycles);
 }

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -202,6 +202,11 @@ void InterpVU1::Shutdown() noexcept {
 	vu1Thread.WaitVU();
 }
 
+void InterpVU1::SetStartPC(u32 startPC)
+{
+	VU1.start_pc = startPC;
+}
+
 void InterpVU1::Step()
 {
 	VU1.VI[REG_TPC].UL &= VU1_PROGMASK;

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -16,12 +16,18 @@
 #include "PrecompiledHeader.h"
 #include "Common.h"
 #include "VUmicro.h"
+#include "MTVU.h"
 
 // Executes a Block based on EE delta time
 void BaseVUmicroCPU::ExecuteBlock(bool startUp) {
 	const u32& stat	= VU0.VI[REG_VPU_STAT].UL;
 	const int  test = m_Idx ? 0x100 : 1;
 	const int s = EmuConfig.Gamefixes.VU0KickstartHack ? 16 : 0; // Kick Start Cycles (Jak needs at least 4 due to writing values after they're read
+
+	if (m_Idx && THREAD_VU1)
+	{
+		vu1Thread.Get_GSChanges();
+	}
 
 	if (!(stat & test)) return;
 

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -21,7 +21,7 @@
 void BaseVUmicroCPU::ExecuteBlock(bool startUp) {
 	const u32& stat	= VU0.VI[REG_VPU_STAT].UL;
 	const int  test = m_Idx ? 0x100 : 1;
-	const int  s = EmuConfig.Gamefixes.VU0KickstartHack ? 16 : 0; // Kick Start Cycles (Jak needs at least 4, DT Racer needs 8192)
+	const int s = EmuConfig.Gamefixes.VU0KickstartHack ? 16 : 0; // Kick Start Cycles (Jak needs at least 4 due to writing values after they're read
 
 	if (!(stat & test)) return;
 

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -264,7 +264,7 @@ extern void vu0Finish();
 extern void iDumpVU0Registers();
 
 // VU1
-extern void vu1Finish();
+extern void vu1Finish(bool add_cycles);
 extern void vu1ResetRegs();
 extern void __fastcall vu1ExecMicro(u32 addr);
 extern void vu1Exec(VURegs* VU);

--- a/pcsx2/VUmicro.h
+++ b/pcsx2/VUmicro.h
@@ -85,6 +85,7 @@ public:
 	virtual void Reserve()=0;
 	virtual void Shutdown()=0;
 	virtual void Reset()=0;
+	virtual void SetStartPC(u32 startPC) = 0;
 	virtual void Execute(u32 cycles)=0;
 	virtual void ExecuteBlock(bool startUp)=0;
 
@@ -172,6 +173,7 @@ public:
 	void Reset() { }
 
 	void Step();
+	void SetStartPC(u32 startPC);
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size) {}
 
@@ -192,6 +194,7 @@ public:
 	void Shutdown() noexcept;
 	void Reset();
 
+	void SetStartPC(u32 startPC);
 	void Step();
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size) {}
@@ -217,6 +220,7 @@ public:
 	void Shutdown() noexcept;
 
 	void Reset();
+	void SetStartPC(u32 startPC);
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size);
 	void Vsync() noexcept;
@@ -237,6 +241,7 @@ public:
 	void Reserve();
 	void Shutdown() noexcept;
 	void Reset();
+	void SetStartPC(u32 startPC);
 	void Execute(u32 cycles);
 	void Clear(u32 addr, u32 size);
 	void Vsync() noexcept;

--- a/pcsx2/Vif.cpp
+++ b/pcsx2/Vif.cpp
@@ -158,28 +158,21 @@ __fi void vif1FBRST(u32 value) {
 		SaveCol._u64[1] = vif1.MaskCol._u64[1];
 		SaveRow._u64[0] = vif1.MaskRow._u64[0];
 		SaveRow._u64[1] = vif1.MaskRow._u64[1];
+		u8 mfifo_empty = vif1.inprogress & 0x10;
 		memzero(vif1);
 		vif1.MaskCol._u64[0] = SaveCol._u64[0];
 		vif1.MaskCol._u64[1] = SaveCol._u64[1];
 		vif1.MaskRow._u64[0] = SaveRow._u64[0];
 		vif1.MaskRow._u64[1] = SaveRow._u64[1];
-		cpuRegs.interrupt &= ~((1 << 1) | (1 << 10)); //Stop all vif1 DMA's
-		///vif1ch.qwc -= std::min((int)vif1ch.qwc, 16); //not sure if the dma should stop, FFWDing could be tricky
-		vif1ch.qwc = 0;
-
-		psHu64(VIF1_FIFO) = 0;
-		psHu64(VIF1_FIFO + 8) = 0;
-		vif1.done = true;
-		vif1ch.chcr.STR = false;
+		
 
 		GUNIT_WARN(Color_Red, "VIF FBRST Reset MSK = %x", vif1Regs.mskpath3);
 		vif1Regs.mskpath3 = false;
 		gifRegs.stat.M3P  = 0;
 		vif1Regs.err.reset();
-		vif1.inprogress = 0;
+		vif1.inprogress = mfifo_empty;
 		vif1.cmd = 0;
 		vif1.vifstalled.enabled = false;
-		vif1.irqoffset.enabled = false;
 		vif1Regs.stat._u32 = 0;
 	}
 

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -312,6 +312,6 @@ void dmaVIF0()
 	//Using a delay as Beyond Good and Evil does the DMA twice with 2 different TADR's (no checks in the middle, all one block of code),
 	//the first bit it sends isnt required for it to work.
 	//Also being an end chain it ignores the second lot, this causes infinite loops ;p
-	// Chain Mode
-	CPU_INT(DMAC_VIF0, 4);
+	if (!vif0Regs.stat.test(VIF0_STAT_VSS | VIF0_STAT_VIS | VIF0_STAT_VFS))
+		CPU_INT(DMAC_VIF0, 4);
 }

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -170,7 +170,7 @@ __fi void vif0Interrupt()
 
 	g_vif0Cycles = 0;
 
-	vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u16)8);
+	vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u32)8);
 
 	if (!(vif0ch.chcr.STR)) Console.WriteLn("vif0 running when CHCR == %x", vif0ch.chcr._u32);
 
@@ -199,7 +199,7 @@ __fi void vif0Interrupt()
 
 			// One game doesn't like vif stalling at end, can't remember what. Spiderman isn't keen on it tho
 			//vif0ch.chcr.STR = false;
-			vif0Regs.stat.FQC = std::min((u16)0x8, vif0ch.qwc);
+			vif0Regs.stat.FQC = std::min((u32)0x8, vif0ch.qwc);
 			if (vif0ch.qwc > 0 || !vif0.done)
 			{
 				vif0Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
@@ -224,7 +224,7 @@ __fi void vif0Interrupt()
 	if (vif0.inprogress & 0x1)
 	{
 		_VIF0chain();
-		vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u16)8);
+		vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u32)8);
 		CPU_INT(DMAC_VIF0, g_vif0Cycles);
 		return;
 	}
@@ -239,7 +239,7 @@ __fi void vif0Interrupt()
 		}
 
 		if ((vif0.inprogress & 0x1) == 0) vif0SetupTransfer();
-		vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u16)8);
+		vif0Regs.stat.FQC = std::min(vif0ch.qwc, (u32)8);
 		CPU_INT(DMAC_VIF0, g_vif0Cycles);
 		return;
 	}
@@ -256,7 +256,7 @@ __fi void vif0Interrupt()
 #endif
 
 	vif0ch.chcr.STR = false;
-	vif0Regs.stat.FQC = std::min((u16)0x8, vif0ch.qwc);
+	vif0Regs.stat.FQC = std::min((u32)0x8, vif0ch.qwc);
 	vif0.vifstalled.enabled = false;
 	vif0.irqoffset.enabled = false;
 	if(vif0.queued_program) vifExecQueue(0);
@@ -307,7 +307,7 @@ void dmaVIF0()
 		vif0.inprogress &= ~0x1;
 	}
 
-	vif0Regs.stat.FQC = std::min((u16)0x8, vif0ch.qwc);
+	vif0Regs.stat.FQC = std::min((u32)0x8, vif0ch.qwc);
 
 	//Using a delay as Beyond Good and Evil does the DMA twice with 2 different TADR's (no checks in the middle, all one block of code),
 	//the first bit it sends isnt required for it to work.

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -136,7 +136,7 @@ __fi void vif0SetupTransfer()
 
 __fi void vif0VUFinish()
 {
-	if (VU0.VI[REG_VPU_STAT].UL & 0x4)
+	if (VU0.VI[REG_VPU_STAT].UL & 0x5)
 	{
 		CPU_INT(VIF_VU0_FINISH, 128);
 		return;

--- a/pcsx2/Vif0_Dma.cpp
+++ b/pcsx2/Vif0_Dma.cpp
@@ -30,6 +30,7 @@ __fi void vif0FLUSH()
 		vif0.waitforvu = true;
 		vif0.vifstalled.enabled = VifStallEnable(vif0ch);
 		vif0.vifstalled.value = VIF_TIMING_BREAK;
+		vif0Regs.stat.VEW = true;
 	}
 	return;
 }
@@ -158,7 +159,7 @@ __fi void vif0VUFinish()
 		vif0.waitforvu = false;
 		ExecuteVU(0);
 		//Make sure VIF0 isnt already scheduled to spin.
-		if(!(cpuRegs.interrupt & 0x1) && vif0ch.chcr.STR && !vif0Regs.stat.INT)
+		if (!(cpuRegs.interrupt & 0x1) && vif0ch.chcr.STR && !vif0Regs.stat.test(VIF0_STAT_VSS | VIF0_STAT_VIS | VIF0_STAT_VFS))
 			vif0Interrupt();
 	}
 	//DevCon.Warning("VU0 state cleared");
@@ -176,7 +177,7 @@ __fi void vif0Interrupt()
 
 	if(vif0.waitforvu)
 	{
-		//CPU_INT(DMAC_VIF0, 16);
+		CPU_INT(VIF_VU0_FINISH, 16);
 		return;
 	}
 

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -235,7 +235,7 @@ __fi void vif1SetupTransfer()
 
 __fi void vif1VUFinish()
 {
-	if (VU0.VI[REG_VPU_STAT].UL & 0x400)
+	if (VU0.VI[REG_VPU_STAT].UL & 0x500)
 	{
 		CPU_INT(VIF_VU1_FINISH, 128);
 		return;

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -489,6 +489,7 @@ void dmaVIF1()
 
 	// Check VIF isn't stalled before starting the loop.
 	// Batman Vengence does something stupid and instead of cancelling a stall it tries to restart VIF, THEN check the stall
-	if (!vif1Regs.stat.test(VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS))
+	// However if VIF FIFO is reversed, it can continue
+	if (!vif1ch.chcr.DIR || !vif1Regs.stat.test(VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS))
 		CPU_INT(DMAC_VIF1, 4);
 }

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -485,6 +485,8 @@ void dmaVIF1()
 
 	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 
-	// Chain Mode
-	CPU_INT(DMAC_VIF1, 4);
+	// Check VIF isn't stalled before starting the loop.
+	// Batman Vengence does something stupid and instead of cancelling a stall it tries to restart VIF, THEN check the stall
+	if (!vif1Regs.stat.test(VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS))
+		CPU_INT(DMAC_VIF1, 4);
 }

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -30,6 +30,7 @@ __fi void vif1FLUSH()
 		vif1.waitforvu = true;
 		vif1.vifstalled.enabled = VifStallEnable(vif1ch);
 		vif1.vifstalled.value = VIF_TIMING_BREAK;
+		vif1Regs.stat.VEW = true;
 	}
 }
 
@@ -242,10 +243,10 @@ __fi void vif1VUFinish()
 
 	if (VU0.VI[REG_VPU_STAT].UL & 0x100)
 	{
-		int _cycles = VU1.cycle;
+		u32 _cycles = VU1.cycle;
 		//DevCon.Warning("Finishing VU1");
-		vu1Finish();
-		CPU_INT(VIF_VU1_FINISH, (VU1.cycle - _cycles) * BIAS); 
+		vu1Finish(false);
+		CPU_INT(VIF_VU1_FINISH, VU1.cycle - _cycles);
 		return;
 	}
 
@@ -270,7 +271,7 @@ __fi void vif1VUFinish()
 		vif1.waitforvu = false;
 		ExecuteVU(1);
 		//Check if VIF is already scheduled to interrupt, if it's waiting, kick it :P
-		if((cpuRegs.interrupt & (1<<DMAC_VIF1 | 1 << DMAC_MFIFO_VIF)) == 0 && vif1ch.chcr.STR && !vif1Regs.stat.INT)
+		if ((cpuRegs.interrupt & ((1 << DMAC_VIF1) | (1 << DMAC_MFIFO_VIF))) == 0 && vif1ch.chcr.STR && !vif1Regs.stat.test(VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS))
 		{
 			if(dmacRegs.ctrl.MFD == MFD_VIF1)
 				vifMFIFOInterrupt();
@@ -327,6 +328,7 @@ __fi void vif1Interrupt()
 	{
 		//DevCon.Warning("Waiting on VU1");
 		//CPU_INT(DMAC_VIF1, 16);
+		CPU_INT(VIF_VU1_FINISH, 16);
 		return;
 	}
 	if (!vif1ch.chcr.STR) Console.WriteLn("Vif1 running when CHCR == %x", vif1ch.chcr._u32);

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -439,6 +439,7 @@ void dmaVIF1()
 	        vif1ch.tadr, vif1ch.asr0, vif1ch.asr1);
 
 	g_vif1Cycles = 0;
+	vif1.inprogress = 0;
 
 	if (vif1ch.qwc > 0)   // Normal Mode
 	{

--- a/pcsx2/Vif1_Dma.cpp
+++ b/pcsx2/Vif1_Dma.cpp
@@ -301,7 +301,7 @@ __fi void vif1Interrupt()
 		//Console.WriteLn("VIFMFIFO\n");
 		// Test changed because the Final Fantasy 12 opening somehow has the tag in *Undefined* mode, which is not in the documentation that I saw.
 		if (vif1ch.chcr.MOD == NORMAL_MODE) Console.WriteLn("MFIFO mode is normal (which isn't normal here)! %x", vif1ch.chcr._u32);
-		vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+		vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 		vifMFIFOInterrupt();
 		return;
 	}
@@ -319,7 +319,7 @@ __fi void vif1Interrupt()
 			return;
 		}
 		vif1Regs.stat.VGW = 0; //Path 3 isn't busy so we don't need to wait for it.
-		vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u16)16);
+		vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 		//Simulated GS transfer time done, clear the flags
 	}
 	
@@ -351,7 +351,7 @@ __fi void vif1Interrupt()
 
 			//NFSHPS stalls when the whole packet has gone across (it stalls in the last 32bit cmd)
 			//In this case VIF will end
-			vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+			vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 			if((vif1ch.qwc > 0 || !vif1.done) && !CHECK_VIF1STALLHACK)	
 			{
 				vif1Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
@@ -378,7 +378,7 @@ __fi void vif1Interrupt()
             _VIF1chain();
             // VIF_NORMAL_FROM_MEM_MODE is a very slow operation.
             // Timesplitters 2 depends on this beeing a bit higher than 128.
-            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u16)16);
+            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 		
 			if(!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
 				CPU_INT(DMAC_VIF1, g_vif1Cycles);
@@ -395,7 +395,7 @@ __fi void vif1Interrupt()
             }
 
             if ((vif1.inprogress & 0x1) == 0) vif1SetupTransfer();
-            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u16)16);
+            if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 
 			if(!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
 	            CPU_INT(DMAC_VIF1, g_vif1Cycles);
@@ -419,7 +419,7 @@ __fi void vif1Interrupt()
 		gifRegs.stat.OPH = false;
 	}
 
-	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u16)16);
+	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min(vif1ch.qwc, (u32)16);
 
 	vif1ch.chcr.STR = false;
 	vif1.vifstalled.enabled = false;
@@ -483,7 +483,7 @@ void dmaVIF1()
 		
 	}
 
-	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+	if (vif1ch.chcr.DIR) vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 
 	// Chain Mode
 	CPU_INT(DMAC_VIF1, 4);

--- a/pcsx2/Vif1_MFIFO.cpp
+++ b/pcsx2/Vif1_MFIFO.cpp
@@ -322,6 +322,7 @@ void vifMFIFOInterrupt()
 			VIF_LOG("VIF1 MFIFO Stalled qwc = %x done = %x inprogress = %x", vif1ch.qwc, vif1.done, vif1.inprogress & 0x10);
 			//Used to check if the MFIFO was empty, there's really no need if it's finished what it needed.
 			if((vif1ch.qwc > 0 || !vif1.done)) {
+				vif1Regs.stat.VPS = VPS_DECODING; //If there's more data you need to say it's decoding the next VIF CMD (Onimusha - Blade Warriors)
 				VIF_LOG("VIF1 MFIFO Stalled");
 				return;
 			}

--- a/pcsx2/Vif1_MFIFO.cpp
+++ b/pcsx2/Vif1_MFIFO.cpp
@@ -295,7 +295,7 @@ void vifMFIFOInterrupt()
 	if(vif1.waitforvu)
 	{
 	//	DevCon.Warning("Waiting on VU1 MFIFO");
-		//CPU_INT(DMAC_MFIFO_VIF, 16);
+		CPU_INT(VIF_VU1_FINISH, 16);
 		return;
 	}
 

--- a/pcsx2/Vif1_MFIFO.cpp
+++ b/pcsx2/Vif1_MFIFO.cpp
@@ -24,7 +24,7 @@ static u32 qwctag(u32 mask)
 	return (dmacRegs.rbor.ADDR + (mask & dmacRegs.rbsr.RMSK));
 }
 
-static u16 QWCinVIFMFIFO(u32 DrainADDR, u16 qwc)
+static u32 QWCinVIFMFIFO(u32 DrainADDR, u32 qwc)
 {
 	u32 ret;
 	
@@ -49,7 +49,7 @@ static u16 QWCinVIFMFIFO(u32 DrainADDR, u16 qwc)
 static __fi bool mfifoVIF1rbTransfer()
 {
 	u32 msize = dmacRegs.rbor.ADDR + dmacRegs.rbsr.RMSK + 16;
-	u16 mfifoqwc = std::min(QWCinVIFMFIFO(vif1ch.madr, vif1ch.qwc), vif1ch.qwc);
+	u32 mfifoqwc = std::min(QWCinVIFMFIFO(vif1ch.madr, vif1ch.qwc), vif1ch.qwc);
 	u32 *src;
 	bool ret;
 	
@@ -318,7 +318,7 @@ void vifMFIFOInterrupt()
 		if (vif1Regs.stat.test(VIF1_STAT_VSS | VIF1_STAT_VIS | VIF1_STAT_VFS)) {
 			//vif1Regs.stat.FQC = 0; // FQC=0
 			//vif1ch.chcr.STR = false;
-			vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+			vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 			VIF_LOG("VIF1 MFIFO Stalled qwc = %x done = %x inprogress = %x", vif1ch.qwc, vif1.done, vif1.inprogress & 0x10);
 			//Used to check if the MFIFO was empty, there's really no need if it's finished what it needed.
 			if((vif1ch.qwc > 0 || !vif1.done)) {
@@ -347,7 +347,7 @@ void vifMFIFOInterrupt()
 		switch(vif1.inprogress & 1) {
 			case 0: //Set up transfer
 				mfifoVIF1transfer();
-				vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+				vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 				
 			case 1: //Transfer data
 				if(vif1.inprogress & 0x1) //Just in case the tag breaks early (or something wierd happens)!
@@ -356,7 +356,7 @@ void vifMFIFOInterrupt()
 				if(!(vif1Regs.stat.VGW && gifUnit.gifPath[GIF_PATH_3].state != GIF_PATH_IDLE)) //If we're waiting on GIF, stop looping, (can be over 1000 loops!)
 					CPU_INT(DMAC_MFIFO_VIF, (g_vif1Cycles == 0 ? 4 : g_vif1Cycles) );	
 
-				vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+				vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 				return;
 		}
 		return;
@@ -371,7 +371,7 @@ void vifMFIFOInterrupt()
 	}
 
 	g_vif1Cycles = 0;
-	vif1Regs.stat.FQC = std::min((u16)0x10, vif1ch.qwc);
+	vif1Regs.stat.FQC = std::min((u32)0x10, vif1ch.qwc);
 	vif1ch.chcr.STR = false;
 	hwDmacIrq(DMAC_VIF1);
 	DMA_LOG("VIF1 MFIFO DMA End");

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -267,6 +267,7 @@ static __fi void _vifCode_MPG(int idx, u32 addr, const u32 *data, int size) {
 
 	if (idx && THREAD_VU1) {
 		vu1Thread.WriteMicroMem(addr, (u8*)data, size*4);
+		vifX.tag.addr = size * 4;
 		return;
 	}
 

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -537,7 +537,8 @@ vifOp(vifCode_STCol) {
 	}
 	pass2 {
 		u32 ret = _vifCode_STColRow<idx>(data, &vifX.MaskCol._u32[vifX.tag.addr]);
-		if (idx) { vu1Thread.WriteCol(vifX); }
+		if (idx && vifX.tag.size == 0)
+			vu1Thread.WriteCol(vifX);
 		return ret;
 	}
 	pass3 { VifCodeLog("STCol"); }
@@ -554,7 +555,8 @@ vifOp(vifCode_STRow) {
 	}
 	pass2 {
 		u32 ret = _vifCode_STColRow<idx>(data, &vifX.MaskRow._u32[vifX.tag.addr]);
-		if (idx) { vu1Thread.WriteRow(vifX); }
+		if (idx && vifX.tag.size == 0)
+			vu1Thread.WriteRow(vifX);
 		return ret;
 	}
 	pass3 { VifCodeLog("STRow"); }

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -96,7 +96,10 @@ static __fi void vuExecMicro(int idx, u32 addr) {
 	}
 
 	GetVifX.queued_program = true;
-	GetVifX.queued_pc = addr & (idx ? 0x7ffu : 0x1ffu);
+	if ((s32)addr == -1)
+		GetVifX.queued_pc = addr;
+	else
+		GetVifX.queued_pc = addr & (idx ? 0x7ffu : 0x1ffu);
 	GetVifX.unpackcalls = 0;
 
 	if (!idx || (!THREAD_VU1 && !INSTANT_VU1))

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -499,10 +499,17 @@ template<int idx> static __fi int _vifCode_STColRow(const u32* data, u32* pmem2)
 	pxAssume(ret > 0);
 
 	switch (ret) {
-		case 4: pmem2[3] = data[3]; // Fall through
-		case 3: pmem2[2] = data[2]; // Fall through
-		case 2: pmem2[1] = data[1]; // Fall through
-		case 1: pmem2[0] = data[0];
+		case 4: 
+			pmem2[3] = data[3]; 
+			// Fall through
+		case 3: 
+			pmem2[2] = data[2];
+			// Fall through
+		case 2: 
+			pmem2[1] = data[1];
+			// Fall through
+		case 1: 
+			pmem2[0] = data[0];
 				break;
 		jNO_DEFAULT
 	}
@@ -530,7 +537,7 @@ vifOp(vifCode_STCol) {
 	}
 	pass2 {
 		u32 ret = _vifCode_STColRow<idx>(data, &vifX.MaskCol._u32[vifX.tag.addr]);
-		if (idx && THREAD_VU1) { vu1Thread.WriteCol(vifX); }
+		if (idx) { vu1Thread.WriteCol(vifX); }
 		return ret;
 	}
 	pass3 { VifCodeLog("STCol"); }
@@ -547,7 +554,7 @@ vifOp(vifCode_STRow) {
 	}
 	pass2 {
 		u32 ret = _vifCode_STColRow<idx>(data, &vifX.MaskRow._u32[vifX.tag.addr]);
-		if (idx && THREAD_VU1) { vu1Thread.WriteRow(vifX); }
+		if (idx) { vu1Thread.WriteRow(vifX); }
 		return ret;
 	}
 	pass3 { VifCodeLog("STRow"); }

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -96,7 +96,7 @@ static __fi void vuExecMicro(int idx, u32 addr) {
 	}
 
 	GetVifX.queued_program = true;
-	GetVifX.queued_pc = addr;
+	GetVifX.queued_pc = addr & (idx ? 0x7ffu : 0x1ffu);
 	GetVifX.unpackcalls = 0;
 
 	if (!idx || (!THREAD_VU1 && !INSTANT_VU1))

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -41,21 +41,16 @@ __ri void vifExecQueue(int idx)
 
 	GetVifX.queued_program = false;
 
-	int startcycles = 0;
-
-	if (!idx) startcycles = VU0.cycle;
-	else      startcycles = VU1.cycle;
-
 	if (!idx) vu0ExecMicro(vif0.queued_pc);
 	else	  vu1ExecMicro(vif1.queued_pc);
 
-	///NOTE: Shadowman 2 has SPS with this, uncommenting the correct code fixes it
-	if (!idx) { startcycles = ((VU0.cycle-startcycles) + ( vif0ch.qwc - (vif0.vifpacketsize >> 2) )); CPU_INT(VIF_VU0_FINISH, 1/*startcycles * BIAS*/); }
-	else      { startcycles = ((VU1.cycle-startcycles) + ( vif1ch.qwc - (vif1.vifpacketsize >> 2) )); CPU_INT(VIF_VU1_FINISH, 1/*startcycles * BIAS*/); }
-
-	//DevCon.Warning("Ran VU%x, VU0 Cycles %x, VU1 Cycles %x, start %x cycle %x", idx, g_vu0Cycles, g_vu1Cycles, startcycles, VU1.cycle);
-	//GetVifX.vifstalled.enabled = VifStallEnable(vifXch);
-	//GetVifX.vifstalled.value = VIF_TIMING_BREAK;
+	// Hack for Wakeboarding Unleashed, game runs a VU program in parallel with a VIF unpack list.
+	// The start of the VU program clears the VU memory, while VIF populates it from behind, so we need to get the clear out of the way.
+	/*if (idx && !INSTANT_VU1)
+	{
+		VU1.cycle -= 256;
+		CpuVU1->ExecuteBlock(0);
+	}*/
 }
 
 static __fi void vifFlush(int idx) {
@@ -103,6 +98,9 @@ static __fi void vuExecMicro(int idx, u32 addr) {
 	GetVifX.queued_program = true;
 	GetVifX.queued_pc = addr;
 	GetVifX.unpackcalls = 0;
+
+	if (!idx || (!THREAD_VU1 && !INSTANT_VU1))
+		vifExecQueue(idx);
 }
 
 void ExecuteVU(int idx)

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -69,8 +69,6 @@ static __fi void vuExecMicro(int idx, u32 addr) {
 	if(GetVifX.waitforvu)
 		return;
 
-	vifRegs.stat.VEW = true;
-
 	if (vifRegs.itops  > (idx ? 0x3ffu : 0xffu)) {
 		Console.WriteLn("VIF%d ITOP overrun! %x", idx, vifRegs.itops);
 		vifRegs.itops &= (idx ? 0x3ffu : 0xffu);

--- a/pcsx2/Vif_Codes.cpp
+++ b/pcsx2/Vif_Codes.cpp
@@ -267,12 +267,20 @@ static __fi void _vifCode_MPG(int idx, u32 addr, const u32 *data, int size) {
 	vifExecQueue(idx);
 
 	if (idx && THREAD_VU1) {
-		vu1Thread.WriteMicroMem(addr, (u8*)data, size*4);
-		vifX.tag.addr = size * 4;
+		if ((addr + size * 4) > vuMemSize)
+		{
+			vu1Thread.WriteMicroMem(addr, (u8*)data, vuMemSize - addr);
+			size -= (vuMemSize - addr) / 4;
+			vu1Thread.WriteMicroMem(0, (u8*)data, size * 4);
+			vifX.tag.addr = size * 4;
+		} 		
+		else
+		{
+			vu1Thread.WriteMicroMem(addr, (u8*)data, size * 4);
+			vifX.tag.addr += size * 4;
+		}
 		return;
-	}
-
-	
+	}	
 
 	// Don't forget the Unsigned designator for these checks
 	if((addr + size *4) > vuMemSize)

--- a/pcsx2/Vif_Transfer.cpp
+++ b/pcsx2/Vif_Transfer.cpp
@@ -90,6 +90,7 @@ _vifT static __fi bool vifTransfer(u32 *data, int size, bool TTE) {
 	if (!TTE) // *WARNING* - Tags CAN have interrupts! so lets just ignore the dma modifying stuffs (GT4)
 	{
 		transferred  = transferred >> 2;
+		transferred = std::min((int)vifXch.qwc, transferred);
 		vifXch.madr +=(transferred << 4);
 		vifXch.qwc  -= transferred;
 

--- a/pcsx2/Vif_Unpack.cpp
+++ b/pcsx2/Vif_Unpack.cpp
@@ -239,7 +239,8 @@ _vifT void vifUnpackSetup(const u32 *data) {
 	//Ugh things are never easy.
 	//Alright, in most cases with V2 and V3 we only need to know if its offset 32bits.
 	//However in V3-16 if the data it requires ends on a QW boundary of the source data
-	//the W vector becomes 0, so we need to know how far through the current QW the data begins
+	//the W vector becomes 0, so we need to know how far through the current QW the data begins.
+	//same happens with V3 8
 	vifX.start_aligned = 4-((vifX.vifpacketsize-1) & 0x3);
 	//DevCon.Warning("Aligned %d packetsize at data start %d", vifX.start_aligned, vifX.vifpacketsize - 1);
 }

--- a/pcsx2/gui-libretro/AppConfig.cpp
+++ b/pcsx2/gui-libretro/AppConfig.cpp
@@ -1040,6 +1040,7 @@ void AppConfig::ResetPresetSettingsToDefault() {
 	EmuOptions.Speedhacks.EECycleRate = 0;
 	EmuOptions.Speedhacks.EECycleSkip = 0;
 	EmuOptions.Speedhacks.vuThread = false;
+	EmuOptions.Speedhacks.vu1Instant = true;
 	EmuOptions.Speedhacks.IntcStat = true;
 	EmuOptions.Speedhacks.WaitLoop = true;
 	EmuOptions.Speedhacks.vuFlagHack = true;

--- a/pcsx2/gui-libretro/AppConfig.cpp
+++ b/pcsx2/gui-libretro/AppConfig.cpp
@@ -986,6 +986,7 @@ bool AppConfig::IsOkApplyPreset(int n, bool ignoreMTVU)
 	EmuOptions.Speedhacks			= default_Pcsx2Config.Speedhacks;
 	EmuOptions.Speedhacks.bitset	= 0; //Turn off individual hacks to make it visually clear they're not used.
 	EmuOptions.Speedhacks.vuThread	= original_SpeedHacks.vuThread;
+	EmuOptions.Speedhacks.vu1Instant = original_SpeedHacks.vu1Instant;
 	EnableSpeedHacks = true;
 	// Actual application of current preset over the base settings which all presets use (mostly pcsx2's default values).
 
@@ -1013,11 +1014,14 @@ bool AppConfig::IsOkApplyPreset(int n, bool ignoreMTVU)
 			EmuOptions.Speedhacks.IntcStat = true;
 			EmuOptions.Speedhacks.WaitLoop = true;
 			EmuOptions.Speedhacks.vuFlagHack = true;
+			EmuOptions.Speedhacks.vu1Instant = true;
+
 			// If waterfalling from > Safe, break to avoid MTVU disable.
 			if (n > 1) break;
             // Fall through
 			
 		case 0: // Safest
+			if (n == 0) EmuOptions.Speedhacks.vu1Instant = false;
 			isMTVUSet ? 0 : (isMTVUSet = true, EmuOptions.Speedhacks.vuThread = false); // Disable MTVU
 			break;
 

--- a/pcsx2/ps2/LegacyDmac.cpp
+++ b/pcsx2/ps2/LegacyDmac.cpp
@@ -278,6 +278,12 @@ static __ri void DmaExec( void (*func)(), u32 mem, u32 value )
 		}
 		reg.chcr.MOD = 0x1;
 	}
+
+	// As tested on hardware, if NORMAL mode is started with 0 QWC it will actually transfer 1 QWC then underflows and transfer another 0xFFFF QWC's
+	// The easiest way to handle this is to just say 0x10000 QWC
+	if (reg.chcr.STR && !reg.chcr.MOD && reg.qwc == 0)
+		reg.qwc = 0x10000;
+
 	if (reg.chcr.STR && dmacRegs.ctrl.DMAE && !psHu8(DMAC_ENABLER+2))
 	{
 		func();
@@ -318,10 +324,22 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D0_QWC) // dma0 - vif0
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D1_CHCR) // dma1 - vif1 - chcr
 		{
 			DMA_LOG("VIF1dma EXECUTE, value=0x%x", value);
 			DmaExec(dmaVIF1, mem, value);
+			return false;
+		}
+
+		icase(D1_QWC) // dma1 - vif1
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 
@@ -332,10 +350,22 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D2_QWC) // dma2 - gif
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D3_CHCR) // dma3 - fromIPU
 		{
 			DMA_LOG("IPU0dma EXECUTE, value=0x%x\n", value);
 			DmaExec(dmaIPU0, mem, value);
+			return false;
+		}
+
+		icase(D3_QWC) // dma3 - fromIPU
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 
@@ -346,10 +376,22 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D4_QWC) // dma4 - toIPU
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D5_CHCR) // dma5 - sif0
 		{
 			DMA_LOG("SIF0dma EXECUTE, value=0x%x", value);
 			DmaExec(dmaSIF0, mem, value);
+			return false;
+		}
+
+		icase(D5_QWC) // dma5 - sif0
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 
@@ -360,6 +402,12 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D6_QWC) // dma6 - sif1
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D7_CHCR) // dma7 - sif2
 		{
 			DMA_LOG("SIF2dma EXECUTE, value=0x%x", value);
@@ -367,10 +415,22 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 			return false;
 		}
 
+		icase(D7_QWC) // dma7 - sif2
+		{
+			psHu32(mem) = (u16)value;
+			return false;
+		}
+
 		icase(D8_CHCR) // dma8 - fromSPR
 		{
 			DMA_LOG("SPR0dma EXECUTE (fromSPR), value=0x%x", value);
 			DmaExec(dmaSPR0, mem, value);
+			return false;
+		}
+
+		icase(D8_QWC) // dma8 - fromSPR
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 
@@ -406,6 +466,12 @@ __fi bool dmacWrite32( u32 mem, mem32_t& value )
 		{
 			DMA_LOG("SPR1dma EXECUTE (toSPR), value=0x%x", value);
 			DmaExec(dmaSPR1, mem, value);
+			return false;
+		}
+
+		icase(D9_QWC) // dma9 - toSPR
+		{
+			psHu32(mem) = (u16)value;
 			return false;
 		}
 

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -73,7 +73,15 @@ void mVUinit(microVU& mVU, uint vuIndex) {
 
 // Resets Rec Data
 void mVUreset(microVU& mVU, bool resetReserve) {
-
+	if (THREAD_VU1)
+	{
+		// If MTVU is toggled on during gameplay we need to flush the running VU1 program, else it gets in a mess
+		if (VU0.VI[REG_VPU_STAT].UL & 0x100)
+		{
+			CpuVU1->Execute(vu1RunCycles);
+		}
+		VU0.VI[REG_VPU_STAT].UL &= ~0x100;
+	}
 	// Restore reserve to uncommitted state
 	if (resetReserve) mVU.cache_reserve->Reset();
 

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -309,6 +309,13 @@ _mVUt __fi void* mVUsearchProg(u32 startPC, uptr pState) {
 	// Because the VU's can now run in sections and not whole programs at once
 	// we need to set the current block so it gets the right program back
 	quick.block = mVU.prog.cur->block[startPC / 8];
+
+	// Sanity check, in case for some reason the program compilation aborted half way through
+	if (quick.block == nullptr)
+	{
+		void* entryPoint = mVUblockFetch(mVU, startPC, pState);
+		return entryPoint;
+	}
 	return mVUentryGet(mVU, quick.block, startPC, pState);
 }
 

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -230,28 +230,27 @@ void mVUprintUniqueRatio(microVU& mVU) {
 	DevCon.WriteLn("%d / %d [%3.1f%%]", v.size(), total, 100.-(double)v.size()/(double)total*100.);
 }
 
-// Compare partial program by only checking compiled ranges...
-__ri bool mVUcmpPartial(microVU& mVU, microProgram& prog) {
-	std::deque<microRange>::const_iterator it(prog.ranges->begin());
-	for ( ; it != prog.ranges->end(); ++it) {
-		if((it[0].start<0)||(it[0].end<0))  { DevCon.Error("microVU%d: Negative Range![%d][%d]", mVU.index, it[0].start, it[0].end); }
-		if (memcmp_mmx(cmpOffset(prog.data), cmpOffset(mVU.regs().Micro), ((it[0].end + 8)  -  it[0].start))) {
-			return 0;
-		}
-	}
-	return 1;
-}
-
 // Compare Cached microProgram to mVU.regs().Micro
 __fi bool mVUcmpProg(microVU& mVU, microProgram& prog, const bool cmpWholeProg) {
-	if ((cmpWholeProg && !memcmp_mmx((u8*)prog.data, mVU.regs().Micro, mVU.microMemSize))
-	|| (!cmpWholeProg && mVUcmpPartial(mVU, prog))) {
-		mVU.prog.cleared =  0;
-		mVU.prog.cur	 = &prog;
-		mVU.prog.isSame  =  cmpWholeProg ? 1 : -1;
-		return true;
+	if (cmpWholeProg)
+	{
+		if (memcmp_mmx((u8*)prog.data, mVU.regs().Micro, mVU.microMemSize))
+			return false;
+	} 
+	else
+	{
+		for (const auto& range : *prog.ranges) {
+			auto cmpOffset = [&](void* x) { return (u8*)x + range.start; };
+			if ((range.start < 0) || (range.end < 0)) { DevCon.Error("microVU%d: Negative Range![%d][%d]", mVU.index, range.start, range.end); }
+			if (memcmp_mmx(cmpOffset(prog.data), cmpOffset(mVU.regs().Micro), ((range.end + 8) - range.start))) {
+				return false;
+			}
+		}
 	}
-	return false;
+	mVU.prog.cleared = 0;
+	mVU.prog.cur = &prog;
+	mVU.prog.isSame = cmpWholeProg ? 1 : -1;
+	return true;
 }
 
 // Searches for Cached Micro Program and sets prog.cur to it (returns entry-point to program)

--- a/pcsx2/x86/microVU.cpp
+++ b/pcsx2/x86/microVU.cpp
@@ -256,8 +256,9 @@ __fi bool mVUcmpProg(microVU& mVU, microProgram& prog, const bool cmpWholeProg) 
 // Searches for Cached Micro Program and sets prog.cur to it (returns entry-point to program)
 _mVUt __fi void* mVUsearchProg(u32 startPC, uptr pState) {
 	microVU& mVU = mVUx;
-	microProgramQuick& quick = mVU.prog.quick[startPC/8];
-	microProgramList*  list  = mVU.prog.prog [startPC/8];
+	microProgramQuick& quick = mVU.prog.quick[mVU.regs().start_pc / 8];
+	microProgramList* list = mVU.prog.prog[mVU.regs().start_pc / 8];
+
 	if(!quick.prog) { // If null, we need to search for new program
 		std::deque<microProgram*>::iterator it(list->begin());
 		for ( ; it != list->end(); ++it) {
@@ -293,7 +294,7 @@ _mVUt __fi void* mVUsearchProg(u32 startPC, uptr pState) {
 		// If cleared and program not found, make a new program instance
 		mVU.prog.cleared	= 0;
 		mVU.prog.isSame		= 1;
-		mVU.prog.cur		= mVUcreateProg(mVU,  startPC/8);
+		mVU.prog.cur		= mVUcreateProg(mVU, mVU.regs().start_pc / 8);
 		void* entryPoint	= mVUblockFetch(mVU,  startPC, pState);
 		quick.block			= mVU.prog.cur->block[startPC/8];
 		quick.prog			= mVU.prog.cur;
@@ -301,9 +302,13 @@ _mVUt __fi void* mVUsearchProg(u32 startPC, uptr pState) {
 		//mVUprintUniqueRatio(mVU);
 		return entryPoint;
 	}
+
 	// If list.quick, then we've already found and recompiled the program ;)
-	mVU.prog.isSame	= -1;
-	mVU.prog.cur	=  quick.prog;
+	mVU.prog.isSame = -1;
+	mVU.prog.cur = quick.prog;
+	// Because the VU's can now run in sections and not whole programs at once
+	// we need to set the current block so it gets the right program back
+	quick.block = mVU.prog.cur->block[startPC / 8];
 	return mVUentryGet(mVU, quick.block, startPC, pState);
 }
 
@@ -347,6 +352,11 @@ void recMicroVU1::Reset() {
 	mVUreset(microVU1, true);
 }
 
+void recMicroVU0::SetStartPC(u32 startPC)
+{
+	VU0.start_pc = startPC;
+}
+
 void recMicroVU0::Execute(u32 cycles) {
 	pxAssert(m_Reserved); // please allocate me first! :|
 
@@ -366,6 +376,12 @@ void recMicroVU0::Execute(u32 cycles) {
 		hwIntcIrq(6);
 	}
 }
+
+void recMicroVU1::SetStartPC(u32 startPC)
+{
+	VU1.start_pc = startPC;
+}
+
 void recMicroVU1::Execute(u32 cycles) {
 	pxAssert(m_Reserved); // please allocate me first! :|
 

--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -71,7 +71,8 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit) {
 	}
 
 	// Save MAC, Status and CLIP Flag Instances
-	xMOV(ptr32[&mVU.regs().VI[REG_STATUS_FLAG].UL], getFlagReg(fStatus));
+	mVUallocSFLAGc(gprT1, gprT2, fStatus);
+	xMOV(ptr32[&mVU.regs().VI[REG_STATUS_FLAG].UL], gprT1);
 	mVUallocMFLAGa(mVU, gprT1, fMac);
 	mVUallocCFLAGa(mVU, gprT2, fClip);
 	xMOV(ptr32[&mVU.regs().VI[REG_MAC_FLAG].UL], gprT1);
@@ -96,7 +97,7 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit) {
 		xSHUF.PS(xmmT1, xmmT1, 0);
 		xMOVAPS(ptr128[&mVU.regs().micro_macflags], xmmT1);
 
-		xMOVDZX(xmmT1, ptr32[&mVU.regs().VI[REG_STATUS_FLAG].UL]);
+		xMOVDZX(xmmT1, getFlagReg(fStatus));
 		xSHUF.PS(xmmT1, xmmT1, 0);
 		xMOVAPS(ptr128[&mVU.regs().micro_statusflags], xmmT1);
 	}
@@ -170,7 +171,8 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 	}
 
 	// Save MAC, Status and CLIP Flag Instances
-	xMOV(ptr32[&mVU.regs().VI[REG_STATUS_FLAG].UL],	getFlagReg(fStatus));
+	mVUallocSFLAGc(gprT1, gprT2, fStatus);
+	xMOV(ptr32[&mVU.regs().VI[REG_STATUS_FLAG].UL], gprT1);
 	mVUallocMFLAGa(mVU, gprT1, fMac);
 	mVUallocCFLAGa(mVU, gprT2, fClip);
 	xMOV(ptr32[&mVU.regs().VI[REG_MAC_FLAG].UL],	gprT1);
@@ -196,7 +198,7 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 		xSHUF.PS(xmmT1, xmmT1, 0);
 		xMOVAPS(ptr128[&mVU.regs().micro_macflags], xmmT1);
 
-		xMOVDZX(xmmT1, ptr32[&mVU.regs().VI[REG_STATUS_FLAG].UL]);
+		xMOVDZX(xmmT1, getFlagReg(fStatus));
 		xSHUF.PS(xmmT1, xmmT1, 0);
 		xMOVAPS(ptr128[&mVU.regs().micro_statusflags], xmmT1);
 	}

--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -118,19 +118,19 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit) {
 
 void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 
-	int fStatus = getLastFlagInst(mVUpBlock->pState, mFC->xStatus, 0, isEbit);
-	int fMac	= getLastFlagInst(mVUpBlock->pState, mFC->xMac,    1, isEbit);
-	int fClip	= getLastFlagInst(mVUpBlock->pState, mFC->xClip,   2, isEbit);
+	int fStatus = getLastFlagInst(mVUpBlock->pState, mFC->xStatus, 0, isEbit && isEbit != 3);
+	int fMac	= getLastFlagInst(mVUpBlock->pState, mFC->xMac, 1, isEbit && isEbit != 3);
+	int fClip	= getLastFlagInst(mVUpBlock->pState, mFC->xClip, 2, isEbit && isEbit != 3);
 	int qInst	= 0;
 	int pInst	= 0;
 	microBlock stateBackup;
 	memcpy(&stateBackup, &mVUregs, sizeof(mVUregs)); //backup the state, it's about to get screwed with.
-	if(!isEbit)
+	if(!isEbit || isEbit == 3)
 		mVU.regAlloc->TDwritebackAll(); //Writing back ok, invalidating early kills the rec, so don't do it :P
 	else
 		mVU.regAlloc->flushAll();
 
-	if (isEbit) {
+	if (isEbit && isEbit != 3) {
 		memzero(mVUinfo);
 		memzero(mVUregsTemp);
 		mVUincCycles(mVU, 100); // Ensures Valid P/Q instances (And sets all cycle data to 0)
@@ -178,7 +178,7 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 	xMOV(ptr32[&mVU.regs().VI[REG_MAC_FLAG].UL],	gprT1);
 	xMOV(ptr32[&mVU.regs().VI[REG_CLIP_FLAG].UL],	gprT2);
 
-	if (!isEbit) { // Backup flag instances
+	if (!isEbit || isEbit == 3) { // Backup flag instances
 		xMOVAPS(xmmT1, ptr128[mVU.macFlag]);
 		xMOVAPS(ptr128[&mVU.regs().micro_macflags], xmmT1);
 		xMOVAPS(xmmT1, ptr128[mVU.clipFlag]);
@@ -204,14 +204,14 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 	}
 
 
-	if (isEbit || isVU1) { // Clear 'is busy' Flags
+	if ((isEbit && isEbit != 3) || isVU1) { // Clear 'is busy' Flags
 		if (!mVU.index || !THREAD_VU1) {
 			xAND(ptr32[&VU0.VI[REG_VPU_STAT].UL], (isVU1 ? ~0x100 : ~0x001)); // VBS0/VBS1 flag
 			//xAND(ptr32[&mVU.getVifRegs().stat], ~VIF1_STAT_VEW); // Clear VU 'is busy' signal for vif
 		}
 	}
 
-	if (isEbit != 2) { // Save PC, and Jump to Exit Point
+	if (isEbit != 2 && isEbit != 3) { // Save PC, and Jump to Exit Point
 		xMOV(ptr32[&mVU.regs().VI[REG_TPC].UL], xPC);
 		xJMP(mVU.exitFunct);
 	}
@@ -292,6 +292,21 @@ void normBranch(mV, microFlagCycles& mFC) {
 		mVUDTendProgram(mVU, &mFC, 1);
 		eJMP.SetTarget();
 		iPC = tempPC;	
+	}
+	if (mVUup.mBit)
+	{
+		DevCon.Warning("M-Bit on normal branch, report if broken");
+		u32 tempPC = iPC;
+		u32* cpS = (u32*)&mVUregs;
+		u32* lpS = (u32*)&mVU.prog.lpState;
+		for (size_t i = 0; i < (sizeof(microRegInfo) - 4) / 4; i++, lpS++, cpS++) {
+			xMOV(ptr32[lpS], cpS[0]);
+		}
+		mVUendProgram(mVU, &mFC, 3);
+		iPC = branchAddr(mVU) / 4;
+		xMOV(ptr32[&mVU.regs().VI[REG_TPC].UL], xPC);
+		xJMP(mVU.exitFunct);
+		iPC = tempPC;
 	}
 	if (mVUup.eBit) { 
 		if(mVUlow.badBranch) 
@@ -408,7 +423,27 @@ void condBranch(mV, microFlagCycles& mFC, int JMPcc) {
 		eJMP.SetTarget();
 		iPC = tempPC;
 	}
-
+	if (mVUup.mBit)
+	{
+		u32 tempPC = iPC;
+		u32* cpS = (u32*)&mVUregs;
+		u32* lpS = (u32*)&mVU.prog.lpState;
+		for (size_t i = 0; i < (sizeof(microRegInfo) - 4) / 4; i++, lpS++, cpS++) {
+			xMOV(ptr32[lpS], cpS[0]);
+		}
+		mVUendProgram(mVU, &mFC, 3);
+		xCMP(ptr16[&mVU.branch], 0);
+		xForwardJump32 dJMP((JccComparisonType)JMPcc);
+		incPC(4); // Set PC to First instruction of Non-Taken Side
+		xMOV(ptr32[&mVU.regs().VI[REG_TPC].UL], xPC);
+		xJMP(mVU.exitFunct);
+		dJMP.SetTarget();
+		incPC(-4); // Go Back to Branch Opcode to get branchAddr
+		iPC = branchAddr(mVU) / 4;
+		xMOV(ptr32[&mVU.regs().VI[REG_TPC].UL], xPC);
+		xJMP(mVU.exitFunct);
+		iPC = tempPC;
+	}
 	if (mVUup.eBit) { // Conditional Branch With E-Bit Set
 		if(mVUlow.evilBranch) 
 			DevCon.Warning("End on evil branch! - Not implemented! - If game broken report to PCSX2 Team");
@@ -471,6 +506,10 @@ void condBranch(mV, microFlagCycles& mFC, int JMPcc) {
 }
 
 void normJump(mV, microFlagCycles& mFC) {
+	if (mVUup.mBit)
+	{
+		DevCon.Warning("M-Bit on Jump! Please report if broken");
+	}
 	if (mVUlow.constJump.isValid) { // Jump Address is Constant
 		if (mVUup.eBit) { // E-bit Jump
 			iPC = (mVUlow.constJump.regValue*2) & (mVU.progMemMask);

--- a/pcsx2/x86/microVU_Branch.inl
+++ b/pcsx2/x86/microVU_Branch.inl
@@ -63,11 +63,20 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit) {
 	}
 
 	// Save P/Q Regs
-	if (qInst) { xPSHUF.D(xmmPQ, xmmPQ, 0xe5); }
+	if (qInst) { xPSHUF.D(xmmPQ, xmmPQ, 0xe1); }
 	xMOVSS(ptr32[&mVU.regs().VI[REG_Q].UL], xmmPQ);
+	xPSHUF.D(xmmPQ, xmmPQ, 0xe1);
+	xMOVSS(ptr32[&mVU.regs().pending_q], xmmPQ);
+	xPSHUF.D(xmmPQ, xmmPQ, 0xe1);
+
 	if (isVU1) {
-		xPSHUF.D(xmmPQ, xmmPQ, pInst ? 3 : 2);
+		xPSHUF.D(xmmPQ, xmmPQ, pInst ? 0x1b : 0x4e);
 		xMOVSS(ptr32[&mVU.regs().VI[REG_P].UL], xmmPQ);
+		xPSHUF.D(xmmPQ, xmmPQ, pInst ? 0x1b : 0x4e);
+
+		xPSHUF.D(xmmPQ, xmmPQ, 0x1b);
+		xMOVSS(ptr32[&mVU.regs().pending_p], xmmPQ);
+		xPSHUF.D(xmmPQ, xmmPQ, 0x1b);
 	}
 
 	// Save MAC, Status and CLIP Flag Instances
@@ -102,7 +111,7 @@ void mVUDTendProgram(mV, microFlagCycles* mFC, int isEbit) {
 		xMOVAPS(ptr128[&mVU.regs().micro_statusflags], xmmT1);
 	}
 
-	if (isEbit || isVU1) { // Clear 'is busy' Flags
+	if (isEbit)	{ // Clear 'is busy' Flags
 		if (!mVU.index || !THREAD_VU1) {
 			xAND(ptr32[&VU0.VI[REG_VPU_STAT].UL], (isVU1 ? ~0x100 : ~0x001)); // VBS0/VBS1 flag
 			xAND(ptr32[&mVU.getVifRegs().stat], ~VIF1_STAT_VEW); // Clear VU 'is busy' signal for vif
@@ -161,11 +170,11 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 	xPSHUF.D(xmmPQ, xmmPQ, 0xe1);
 
 	if (isVU1) {
-		xPSHUF.D(xmmPQ, xmmPQ, pInst ? 0x1b : 0x1e);
+		xPSHUF.D(xmmPQ, xmmPQ, pInst ? 0x1b : 0x4e);
 		xMOVSS(ptr32[&mVU.regs().VI[REG_P].UL], xmmPQ);
-		xPSHUF.D(xmmPQ, xmmPQ, pInst ? 0x1b : 0x4b);
+		xPSHUF.D(xmmPQ, xmmPQ, pInst ? 0x1b : 0x4e);
 
-		xPSHUF.D(xmmPQ, xmmPQ, 0xe1);
+		xPSHUF.D(xmmPQ, xmmPQ, 0x1b);
 		xMOVSS(ptr32[&mVU.regs().pending_p], xmmPQ);
 		xPSHUF.D(xmmPQ, xmmPQ, 0x1b);
 	}
@@ -204,7 +213,7 @@ void mVUendProgram(mV, microFlagCycles* mFC, int isEbit) {
 	}
 
 
-	if ((isEbit && isEbit != 3) || isVU1) { // Clear 'is busy' Flags
+	if ((isEbit && isEbit != 3)) { // Clear 'is busy' Flags
 		if (!mVU.index || !THREAD_VU1) {
 			xAND(ptr32[&VU0.VI[REG_VPU_STAT].UL], (isVU1 ? ~0x100 : ~0x001)); // VBS0/VBS1 flag
 			//xAND(ptr32[&mVU.getVifRegs().stat], ~VIF1_STAT_VEW); // Clear VU 'is busy' signal for vif

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -491,8 +491,6 @@ void* mVUcompileSingleInstruction(microVU& mVU, u32 startPC, uptr pState, microF
 	mVUsetFlags(mVU, mFC);           // Sets Up Flag instances
 	mVUoptimizePipeState(mVU);       // Optimize the End Pipeline State for nicer Block Linking
 	mVUdebugPrintBlocks(mVU, false); // Prints Start/End PC of blocks executed, for debugging...
-	
-	mVUtestCycles(mVU, mFC);              // Update VU Cycles and Exit Early if Necessary
 
 	// Second Pass
 	iPC = startPC / 4;

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -692,6 +692,12 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 			goto perf_and_return;
 		}
 		else if (!mVUinfo.isBdelay) {
+			// Handle range wrapping
+			if ((xPC + 8) == mVU.microMemSize)
+			{
+				mVUsetupRange(mVU, xPC, false);
+				mVUsetupRange(mVU, 0, 1);
+			}
 			incPC(1);
 		}
 		else {

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -561,6 +561,9 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 		mVUcheckBadOp(mVU);
 		if (curI & _Ebit_) {
 			eBitPass1(mVU, branch);
+			// VU0 end of program MAC results can be read by COP2, so best to make sure the last instance is valid
+			// Needed for State of Emergency 2 and Driving Emotion Type-S
+			if (isVU0) mVUregs.needExactMatch |= 7;
 		}
 
 		if ((curI & _Mbit_) && isVU0) {

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -564,7 +564,13 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 		}
 
 		if ((curI & _Mbit_) && isVU0) {
-			mVUup.mBit = true;
+			incPC(-2);
+			if (!(curI & _Mbit_)) { //If the last instruction was also M-Bit we don't need to sync again
+				incPC(2);
+				mVUup.mBit = true;
+			} 
+			else
+				incPC(2);
 		}
 
 		if (curI & _Ibit_) {
@@ -611,7 +617,10 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 		}
 
 		if (mVUup.mBit && !branch && !mVUup.eBit)
+		{
+			mVUregs.needExactMatch |= 7;
 			break;
+		}
 
 		if (mVUinfo.isEOB)
 			break;
@@ -652,6 +661,10 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 				mVUDoDBit(mVU, &mFC);
 			}
 			else if (mVUup.mBit && !mVUup.eBit && !mVUinfo.isEOB) {
+				// Need to make sure the flags are exact, Gungrave does FCAND with Mbit, then directly after FMAND with M-bit
+				// Also call setupBranch to sort flag instances
+
+				mVUsetupBranch(mVU, mFC);
 				// Make sure we save the current state so it can come back to it
 				u32* cpS = (u32*)&mVUregs;
 				u32* lpS = (u32*)&mVU.prog.lpState;

--- a/pcsx2/x86/microVU_Compile.inl
+++ b/pcsx2/x86/microVU_Compile.inl
@@ -567,13 +567,18 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 		}
 
 		if ((curI & _Mbit_) && isVU0) {
-			incPC(-2);
-			if (!(curI & _Mbit_)) { //If the last instruction was also M-Bit we don't need to sync again
-				incPC(2);
-				mVUup.mBit = true;
-			} 
+			if (xPC > 0)
+			{
+				incPC(-2);
+				if (!(curI & _Mbit_)) { //If the last instruction was also M-Bit we don't need to sync again
+					incPC(2);
+					mVUup.mBit = true;
+				} 
+				else
+					incPC(2);
+			}
 			else
-				incPC(2);
+				mVUup.mBit = true;
 		}
 
 		if (curI & _Ibit_) {
@@ -677,6 +682,7 @@ void* mVUcompile(microVU& mVU, u32 startPC, uptr pState)
 				mVUsetupRange(mVU, xPC, false);
 				incPC(2);
 				mVUendProgram(mVU, &mFC, 0);
+				normBranchCompile(mVU, xPC);
 				incPC(-2);
 				goto perf_and_return;
 			}
@@ -773,6 +779,7 @@ _mVUt void* __fastcall mVUcompileJIT(u32 startPC, uptr ptr) {
 	if (doJumpAsSameProgram) { // Treat jump as part of same microProgram
 		return mVUblockFetch(mVUx, startPC, ptr);
 	}
+	mVUx.regs().start_pc = startPC;
 	if (doJumpCaching) { // When doJumpCaching, ptr is a microBlock pointer
 		microVU& mVU = mVUx;
 		microBlock* pBlock = (microBlock*)ptr;

--- a/pcsx2/x86/microVU_Execute.inl
+++ b/pcsx2/x86/microVU_Execute.inl
@@ -95,11 +95,10 @@ void mVUdispatcherCD(mV) {
 		xLDMXCSR(g_sseVUMXCSR);
 
 		mVUrestoreRegs(mVU);
-
-		xMOV(gprF0, ptr32[&mVU.statFlag[0]]);
-		xMOV(gprF1, ptr32[&mVU.statFlag[1]]);
-		xMOV(gprF2, ptr32[&mVU.statFlag[2]]);
-		xMOV(gprF3, ptr32[&mVU.statFlag[3]]);
+		xMOV(gprF0, ptr32[&mVU.regs().micro_statusflags[0]]);
+		xMOV(gprF1, ptr32[&mVU.regs().micro_statusflags[1]]);
+		xMOV(gprF2, ptr32[&mVU.regs().micro_statusflags[2]]);
+		xMOV(gprF3, ptr32[&mVU.regs().micro_statusflags[3]]);
 
 		// Jump to Recompiled Code Block
 		xJMP(ptrNative[&mVU.resumePtrXG]);
@@ -110,10 +109,10 @@ void mVUdispatcherCD(mV) {
 		//xMOV(ptr32[&mVU.resumePtrXG], gprT1);
 
 		// Backup Status Flag (other regs were backed up on xgkick)
-		xMOV(ptr32[&mVU.statFlag[0]], gprF0);
-		xMOV(ptr32[&mVU.statFlag[1]], gprF1);
-		xMOV(ptr32[&mVU.statFlag[2]], gprF2);
-		xMOV(ptr32[&mVU.statFlag[3]], gprF3);
+		xMOV(ptr32[&mVU.regs().micro_statusflags[0]], gprF0);
+		xMOV(ptr32[&mVU.regs().micro_statusflags[1]], gprF1);
+		xMOV(ptr32[&mVU.regs().micro_statusflags[2]], gprF2);
+		xMOV(ptr32[&mVU.regs().micro_statusflags[3]], gprF3);
 
 		// Load EE's MXCSR state
 		xLDMXCSR(g_sseMXCSR);

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -79,6 +79,9 @@ mVUop(mVU_DIV) {
 
 		writeQreg(Fs, mVUinfo.writeQ);
 
+		if (mVU.cop2)
+			xOR(gprF0, ptr32[&mVU.divFlag]);
+
 		mVU.regAlloc->clearNeeded(Fs);
 		mVU.regAlloc->clearNeeded(Ft);
 		mVU.regAlloc->clearNeeded(t1);
@@ -98,6 +101,9 @@ mVUop(mVU_SQRT) {
 		if (CHECK_VU_OVERFLOW) xMIN.SS(Ft, ptr32[mVUglob.maxvals]); // Clamp infinities (only need to do positive clamp since xmmFt is positive)
 		xSQRT.SS(Ft, Ft);
 		writeQreg(Ft, mVUinfo.writeQ);
+
+		if (mVU.cop2)
+			xOR(gprF0, ptr32[&mVU.divFlag]);
 
 		mVU.regAlloc->clearNeeded(Ft);
 		mVU.profiler.EmitOp(opSQRT);
@@ -137,6 +143,9 @@ mVUop(mVU_RSQRT) {
 		djmp.SetTarget();
 
 		writeQreg(Fs, mVUinfo.writeQ);
+
+		if (mVU.cop2)
+			xOR(gprF0, ptr32[&mVU.divFlag]);
 
 		mVU.regAlloc->clearNeeded(Fs);
 		mVU.regAlloc->clearNeeded(Ft);

--- a/pcsx2/x86/microVU_Lower.inl
+++ b/pcsx2/x86/microVU_Lower.inl
@@ -80,7 +80,10 @@ mVUop(mVU_DIV) {
 		writeQreg(Fs, mVUinfo.writeQ);
 
 		if (mVU.cop2)
+		{
+			xAND(gprF0, ~0xc0000);
 			xOR(gprF0, ptr32[&mVU.divFlag]);
+		}
 
 		mVU.regAlloc->clearNeeded(Fs);
 		mVU.regAlloc->clearNeeded(Ft);
@@ -103,7 +106,10 @@ mVUop(mVU_SQRT) {
 		writeQreg(Ft, mVUinfo.writeQ);
 
 		if (mVU.cop2)
+		{
+			xAND(gprF0, ~0xc0000);
 			xOR(gprF0, ptr32[&mVU.divFlag]);
+		}
 
 		mVU.regAlloc->clearNeeded(Ft);
 		mVU.profiler.EmitOp(opSQRT);
@@ -145,7 +151,10 @@ mVUop(mVU_RSQRT) {
 		writeQreg(Fs, mVUinfo.writeQ);
 
 		if (mVU.cop2)
+		{
+			xAND(gprF0, ~0xc0000);
 			xOR(gprF0, ptr32[&mVU.divFlag]);
+		}
 
 		mVU.regAlloc->clearNeeded(Fs);
 		mVU.regAlloc->clearNeeded(Ft);

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -203,9 +203,9 @@ REC_COP2_mVU0(CLIP,		"CLIP",		0x08);
 // Macro VU - Redirect Lower Instructions
 //------------------------------------------------------------------
 
-REC_COP2_mVU0(DIV,		"DIV",		0x02);
-REC_COP2_mVU0(SQRT,		"SQRT",		0x02);
-REC_COP2_mVU0(RSQRT,	"RSQRT",	0x02);
+REC_COP2_mVU0(DIV,		"DIV",		0x12);
+REC_COP2_mVU0(SQRT,		"SQRT",		0x12);
+REC_COP2_mVU0(RSQRT,	"RSQRT",	0x12);
 REC_COP2_mVU0(IADD,		"IADD",		0x04);
 REC_COP2_mVU0(IADDI,	"IADDI",	0x04);
 REC_COP2_mVU0(IAND,		"IAND",		0x04);

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -247,8 +247,8 @@ INTERPRETATE_COP2_FUNC(CALLMSR);
 void _setupBranchTest(u32*(jmpType)(u32), bool isLikely) {
 	printCOP2("COP2 Branch");
 	_eeFlushAllUnused();
-	xTEST(ptr32[&vif1Regs.stat._u32], 0x4);
-	//TEST32ItoM((uptr)&VU0.VI[REG_VPU_STAT].UL, 0x100);
+	//xTEST(ptr32[&vif1Regs.stat._u32], 0x4);
+	xTEST(ptr32[&VU0.VI[REG_VPU_STAT].UL], 0x100);
 	recDoBranchImm(jmpType(0), isLikely);
 }
 
@@ -397,12 +397,13 @@ static void recCTC2() {
 			break;
 		}
 		case REG_CMSAR1:	// Execute VU1 Micro SubRoutine
+			xMOV(ecx, 1);
+			xFastCall((void*)vu1Finish, ecx);
 			if (_Rt_) {
 				xMOV(ecx, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
 			}
 			else xXOR(ecx, ecx);
 			xFastCall((void*)vu1ExecMicro, ecx);
-			xFastCall((void*)vif1VUFinish);
 			break;
 		case REG_FBRST:
 			if (!_Rt_) {

--- a/pcsx2/x86/microVU_Macro.inl
+++ b/pcsx2/x86/microVU_Macro.inl
@@ -51,8 +51,10 @@ void setupMacroOp(int mode, const char* opName) {
 		microVU0.prog.IRinfo.info[0].sFlag.lastWrite   = 0;
 		microVU0.prog.IRinfo.info[0].mFlag.doFlag      = true;
 		microVU0.prog.IRinfo.info[0].mFlag.write       = 0xff;
-		
-		xMOV(gprF0, ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL]);
+		//Denormalize
+		mVUallocSFLAGd(&vu0Regs.VI[REG_STATUS_FLAG].UL);
+
+		xMOV(gprF0, eax);
 	}
 }
 
@@ -61,12 +63,15 @@ void endMacroOp(int mode) {
 		xMOVSS(ptr32[&vu0Regs.VI[REG_Q].UL], xmmPQ);
 	}
 	if (mode & 0x10) { // Status/Mac Flags were Updated
-		xMOV(ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL], gprF0);
+		// Normalize
+		mVUallocSFLAGc(eax, gprF0, 0);
+		xMOV(ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL], eax);
 	}
 	microVU0.regAlloc->flushAll();
 
 	if (mode & 0x10) { // Update VU0 Status/Mac instances after flush to avoid corrupting anything
-		xMOVDZX(xmmT1, ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL]);
+		mVUallocSFLAGd(&vu0Regs.VI[REG_STATUS_FLAG].UL);
+		xMOVDZX(xmmT1, eax);
 		xSHUF.PS(xmmT1, xmmT1, 0);
 		xMOVAPS(ptr128[&microVU0.regs().micro_statusflags], xmmT1);
 
@@ -295,8 +300,7 @@ static void recCFC2() {
 	iFlushCall(FLUSH_EVERYTHING);
 
 	if (_Rd_ == REG_STATUS_FLAG) { // Normalize Status Flag
-		xMOV(gprF0, ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL]);
-		mVUallocSFLAGc(eax, gprF0, 0);
+		xMOV(eax, ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL]);
 	}
 	else xMOV(eax, ptr32[&vu0Regs.VI[_Rd_].UL]);
 
@@ -375,21 +379,20 @@ static void recCTC2() {
 			break;
 		case REG_STATUS_FLAG:
 		{
-			if (_Rt_) { // Denormalizes flag into eax (gprT1)
-				mVUallocSFLAGd(&cpuRegs.GPR.r[_Rt_].UL[0]);
-				xMOV(ptr32[&vu0Regs.VI[_Rd_].UL], eax);
+			if (_Rt_) {
+				xMOV(eax, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
+				xAND(eax, 0xFC0);
+				xAND(ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL], 0x3F);
+				xOR(ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL], eax);
+
 			}
-			else xMOV(ptr32[&vu0Regs.VI[_Rd_].UL], 0);
-			__aligned16 static const u32 sticky_flags[4] = { 0xFC0,0xFC0,0xFC0,0xFC0 };
-			__aligned16 static const u32 status_flags[4] = { 0x3F,0x3F,0x3F,0x3F };
+			else xAND(ptr32[&vu0Regs.VI[REG_STATUS_FLAG].UL], 0x3F);
 
 			//Need to update the sticky flags for microVU
-			xMOVDZX(xmmT1, ptr32[&cpuRegs.GPR.r[_Rt_].UL[0]]);
+			mVUallocSFLAGd(&vu0Regs.VI[REG_STATUS_FLAG].UL);
+			xMOVDZX(xmmT1, eax);
 			xSHUF.PS(xmmT1, xmmT1, 0);
-			xAND.PS(xmmT1, ptr128[&sticky_flags]);
-			xMOVAPS(xmmT2, ptr128[&vu0Regs.micro_statusflags]);
-			xAND.PS(xmmT1, ptr128[&status_flags]);
-			xOR.PS(xmmT1, xmmT2);
+			// Make sure the values are everywhere the need to be
 			xMOVAPS(ptr128[&vu0Regs.micro_statusflags], xmmT1);
 			break;
 		}

--- a/pcsx2/x86/microVU_Misc.h
+++ b/pcsx2/x86/microVU_Misc.h
@@ -229,7 +229,6 @@ typedef u32 (__fastcall *mVUCall)(void*, void*);
 #define setCode()	 { mVU.code = curI; }
 #define bSaveAddr	 (((xPC + 16) & (mVU.microMemSize-8)) / 8)
 #define shufflePQ	 (((mVU.p) ? 0xb0 : 0xe0) | ((mVU.q) ? 0x01 : 0x04))
-#define cmpOffset(x) ((u8*)&(((u8*)x)[it[0].start]))
 #define Rmem		 &mVU.regs().VI[REG_R].UL
 #define aWrap(x, m)	 ((x > m) ? 0 : x)
 #define shuffleSS(x) ((x==1)?(0x27):((x==2)?(0xc6):((x==4)?(0xe1):(0xe4))))

--- a/pcsx2/x86/microVU_Tables.inl
+++ b/pcsx2/x86/microVU_Tables.inl
@@ -211,7 +211,7 @@ mVUop(mVULowerOP_T3_11)	{ mVULowerOP_T3_11_OPCODE	[((mVU.code >> 6) & 0x1f)](mX)
 mVUop(mVUopU)			{ mVU_UPPER_OPCODE			[ (mVU.code & 0x3f) ](mX); } // Gets Upper Opcode
 mVUop(mVUopL)			{ mVULOWER_OPCODE			[ (mVU.code >>  25) ](mX); } // Gets Lower Opcode
 mVUop(mVUunknown) {
-	pass1 { mVUinfo.isBadOp = true; }
+	pass1{ if (mVU.code != 0x8000033c) mVUinfo.isBadOp = true; }
 	pass2 { if(mVU.code != 0x8000033c) Console.Error("microVU%d: Unknown Micro VU opcode called (%x) [%04x]\n", getIndex, mVU.code, xPC); }
 	pass3 { mVUlog("Unknown", mVU.code); }
 }

--- a/pcsx2/x86/newVif_Dynarec.cpp
+++ b/pcsx2/x86/newVif_Dynarec.cpp
@@ -184,7 +184,7 @@ void VifUnpackSSE_Dynarec::ModUnpack( int upknum, bool PostOp )
 
 		case 8: if(PostOp) { UnpkLoopIteration++; UnpkLoopIteration = UnpkLoopIteration & 0x1; } break;
 		case 9:	if (!PostOp) { UnpkLoopIteration++; } break;
-		case 10: 	break;
+		case 10:if (!PostOp) { UnpkLoopIteration++; } break;
 
 		case 12: 	break;
 		case 13: 	break;

--- a/pcsx2/x86/newVif_UnpackSSE.cpp
+++ b/pcsx2/x86/newVif_UnpackSSE.cpp
@@ -289,6 +289,8 @@ void VifUnpackSSE_Base::xUPK_V3_8() const {
 		xPUNPCK.LWD(destReg, destReg);
 		xShiftR    (destReg, 24);
 	}
+	if (UnpkLoopIteration != IsAligned)
+		xAND.PS(destReg, ptr128[SSEXYZWMask[0]]);
 }
 
 void VifUnpackSSE_Base::xUPK_V4_32() const {


### PR DESCRIPTION
Backports https://github.com/PCSX2/pcsx2/pull/3864 + all the VU, MTVU, COP2, MFIFO, microVU, DMA, IPU, and VIF improvements listed in the standalone's [Q4 2020 Progress Report](https://pcsx2.net/297-q4-2020-progress-report.html), which gives a nice overview of the changes.

Additionally, the `InstantVU1SpeedHack` entries in the GameDB are now functional.