### PR TITLE
Added texture filtering option + fix for GSRenderer options initialization

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -156,15 +156,31 @@ struct retro_core_option_definition option_defs[] = {
 	},
 	"0" },
 
+	{ "pcsx2_texture_filtering",
+	"Video: Texture Filtering",
+	"Controls the texture filtering of the emulation "
+		"\nNearest: always disable interpolation, rendering will be blocky. "
+		"\nBilinear Forced: always enable interpolation. Rendering is smoother but it could generate some glitches. "
+		"\nBilinear PS2: use same mode as the PS2. It is the more accurate option."
+		"\nBilinear Forced (excluding sprite): always enable interpolation except for sprites (FMV/Text/2D elements). Rendering is smoother but it could generate a few glitches. If upscaling is enabled, this setting is recommended over 'Bilinear Forced ",
+	{
+		{"0", "Nearest"},
+		{"1", "Bilinear (Forced)"},
+		{"2", "Bilinear (PS2 - Default)"},
+		{"3", "Bilinear (Forced Excluding Sprite)"},
+		{NULL, NULL},
+	},
+	"2" },
+
 	{ "pcsx2_frameskip",
-"Video: Frame Skip",
-NULL,
-{
-	{"disabled", NULL},
-	{"enabled", NULL},
-	{NULL, NULL},
-},
-"disabled" },
+	"Video: Frame Skip",
+	NULL,
+	{
+		{"disabled", NULL},
+		{"enabled", NULL},
+		{NULL, NULL},
+	},
+	"disabled" },
 
 	{ "pcsx2_frames_to_draw",
 	"Video: Frameskip - Frames to Draw",

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -362,7 +362,7 @@ void retro_init(void)
 	g_Conf->EmuOptions.GS.FramesToDraw = option_value(INT_PCSX2_OPT_FRAMES_TO_DRAW, KeyOptionInt::return_type);
 	g_Conf->EmuOptions.GS.FramesToSkip = option_value(INT_PCSX2_OPT_FRAMES_TO_SKIP, KeyOptionInt::return_type);
 	g_Conf->EmuOptions.EnableCheats = option_value(BOOL_PCSX2_OPT_ENABLE_CHEATS, KeyOptionBool::return_type);
-	
+
 
 	static retro_disk_control_ext_callback disk_control = {
 		DiskControl::set_eject_state,

--- a/libretro/options_tools.h
+++ b/libretro/options_tools.h
@@ -51,6 +51,7 @@ static const char* INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX	= "pcsx2_userhack_halfs
 static const char* INT_PCSX2_OPT_GAMEPAD_RUMBLE_FORCE		= "pcsx2_rumble_intensity";
 static const char* INT_PCSX2_OPT_DEINTERLACING_MODE			= "pcsx2_deinterlace_mode";
 static const char* INT_PCSX2_OPT_FXAA						= "pcsx2_fxaa";
+static const char* INT_PCSX2_OPT_TEXTURE_FILTERING			= "pcsx2_texture_filtering";
 
 
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -58,7 +58,13 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 		m_userhacks_tcoffset_x           = theApp.GetConfigI("UserHacks_TCOffsetX") / -1000.0f;
 		m_userhacks_tcoffset_y           = theApp.GetConfigI("UserHacks_TCOffsetY") / -1000.0f;
 		m_userhacks_tcoffset             = m_userhacks_tcoffset_x < 0.0f || m_userhacks_tcoffset_y < 0.0f;
-	} else {
+	} //else {
+	/*
+	* FIX ME: Probably due to VU-related backports #66, some users complained about configured hack not applied  
+	* at start of the game. Not sure why, but now theApp.GetConfigB("UserHacks") it's true 
+	* and don't precess the "else". Games tested do not apply hacks like "Align Sprite",and probably also others hacks.
+	* For the momemnt this "else" is commented so the UserHacks  are overwritten from the options hacks here below, choosen by the user
+	*/
 		m_userhacks_enabled_gs_mem_clear = true;
 		m_userHacks_enabled_unscale_ptln = true;
 #ifdef __LIBRETRO__
@@ -80,7 +86,7 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 		m_userhacks_ts_half_bottom = -1;
 #endif
 		
-	}
+	//}
 #ifdef __LIBRETRO__
 
 	m_upscale_multiplier = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -43,63 +43,42 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	, m_lod(GSVector2i(0,0))
 {
 	m_mipmap = theApp.GetConfigI("mipmap_hw");
-	m_upscale_multiplier = theApp.GetConfigI("upscale_multiplier");
 	m_large_framebuffer  = theApp.GetConfigB("large_framebuffer");
 	m_accurate_date = theApp.GetConfigI("accurate_date");
 
-	if (theApp.GetConfigB("UserHacks")) {
-		m_userhacks_enabled_gs_mem_clear = !theApp.GetConfigB("UserHacks_Disable_Safe_Features");
-		m_userHacks_enabled_unscale_ptln = !theApp.GetConfigB("UserHacks_Disable_Safe_Features");
-		m_userhacks_align_sprite_X       = theApp.GetConfigB("UserHacks_align_sprite_X");
-		m_userHacks_merge_sprite         = theApp.GetConfigB("UserHacks_merge_pp_sprite");
-		m_userhacks_ts_half_bottom       = theApp.GetConfigI("UserHacks_Half_Bottom_Override");
-		m_userhacks_round_sprite_offset  = theApp.GetConfigI("UserHacks_round_sprite_offset");
-		m_userHacks_HPO                  = theApp.GetConfigI("UserHacks_HalfPixelOffset");
-		m_userhacks_tcoffset_x           = theApp.GetConfigI("UserHacks_TCOffsetX") / -1000.0f;
-		m_userhacks_tcoffset_y           = theApp.GetConfigI("UserHacks_TCOffsetY") / -1000.0f;
-		m_userhacks_tcoffset             = m_userhacks_tcoffset_x < 0.0f || m_userhacks_tcoffset_y < 0.0f;
-	} //else {
-	/*
-	* FIX ME: Probably due to VU-related backports #66, some users complained about configured hack not applied  
-	* at start of the game. Not sure why, but now theApp.GetConfigB("UserHacks") it's true 
-	* and don't precess the "else". Games tested do not apply hacks like "Align Sprite",and probably also others hacks.
-	* For the momemnt this "else" is commented so the UserHacks  are overwritten from the options hacks here below, choosen by the user
-	*/
-		m_userhacks_enabled_gs_mem_clear = true;
-		m_userHacks_enabled_unscale_ptln = true;
-#ifdef __LIBRETRO__
-		m_userhacks_align_sprite_X		= option_value(BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE, KeyOptionBool::return_type);
-		m_userHacks_merge_sprite		= option_value(BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE, KeyOptionBool::return_type);
-		int skipdraw_start				= option_value(INT_PCSX2_OPT_USERHACK_SKIPDRAW_START, KeyOptionInt::return_type);
-		int skipdraw_layers				= option_value(INT_PCSX2_OPT_USERHACK_SKIPDRAW_LAYERS, KeyOptionInt::return_type);
-		m_userhacks_skipdraw_offset		= skipdraw_start;
-		m_userhacks_skipdraw			= skipdraw_start + skipdraw_layers;
-		m_userHacks_HPO					= option_value(INT_PCSX2_OPT_USERHACK_HALFPIXEL_OFFSET, KeyOptionInt::return_type);
-		m_userhacks_round_sprite_offset = option_value(INT_PCSX2_OPT_USERHACK_ROUND_SPRITE, KeyOptionInt::return_type);
-		m_userhacks_wildhack			= option_value(BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET, KeyOptionBool::return_type);
-		m_userhacks_ts_half_bottom		= option_value(INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX, KeyOptionInt::return_type);
-#else
-		m_userhacks_align_sprite_X      = false;
-		m_userHacks_merge_sprite		= false;
-		m_userHacks_HPO					= 0;
-		m_userhacks_round_sprite_offset = 0;
-		m_userhacks_ts_half_bottom = -1;
-#endif
-		
-	//}
-#ifdef __LIBRETRO__
-
-	m_upscale_multiplier = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
 	theApp.SetConfig("MaxAnisotropy", option_value(INT_PCSX2_OPT_ANISOTROPIC_FILTER, KeyOptionInt::return_type));
 	theApp.SetConfig("filter", option_value(INT_PCSX2_OPT_TEXTURE_FILTERING, KeyOptionInt::return_type));
+
 	m_fxaa = option_value(INT_PCSX2_OPT_FXAA, KeyOptionInt::return_type);
 	theApp.SetConfig("fxaa", m_fxaa);
+	
 	m_interlace = option_value(INT_PCSX2_OPT_DEINTERLACING_MODE, KeyOptionInt::return_type);
 	theApp.SetConfig("interlace", m_interlace);
 
-	
+	m_userhacks_enabled_gs_mem_clear = true;
+	m_userHacks_enabled_unscale_ptln = true;
 
-#endif
+	m_upscale_multiplier			= option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
+
+	m_userhacks_align_sprite_X		= option_value(BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE, KeyOptionBool::return_type);
+	m_userHacks_merge_sprite		= option_value(BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE, KeyOptionBool::return_type);
+	int skipdraw_start				= option_value(INT_PCSX2_OPT_USERHACK_SKIPDRAW_START, KeyOptionInt::return_type);
+	int skipdraw_layers				= option_value(INT_PCSX2_OPT_USERHACK_SKIPDRAW_LAYERS, KeyOptionInt::return_type);
+	m_userhacks_skipdraw_offset		= skipdraw_start;
+	m_userhacks_skipdraw			= skipdraw_start + skipdraw_layers;
+	m_userHacks_HPO					= option_value(INT_PCSX2_OPT_USERHACK_HALFPIXEL_OFFSET, KeyOptionInt::return_type);
+	m_userhacks_round_sprite_offset = option_value(INT_PCSX2_OPT_USERHACK_ROUND_SPRITE, KeyOptionInt::return_type);
+	m_userhacks_wildhack			= option_value(BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET, KeyOptionBool::return_type);
+	m_userhacks_ts_half_bottom		= option_value(INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX, KeyOptionInt::return_type);
+	m_userhacks_auto_flush			= option_value(BOOL_PCSX2_OPT_USERHACK_AUTO_FLUSH, KeyOptionBool::return_type);
+
+	theApp.SetConfig("UserHacks_AutoFlush", m_userhacks_auto_flush);
+
+	m_userhacks_tcoffset_x	= theApp.GetConfigI("UserHacks_TCOffsetX") / -1000.0f;
+	m_userhacks_tcoffset_y	= theApp.GetConfigI("UserHacks_TCOffsetY") / -1000.0f;
+	m_userhacks_tcoffset	= m_userhacks_tcoffset_x < 0.0f || m_userhacks_tcoffset_y < 0.0f;
+
+
 	if (!m_upscale_multiplier) { //Custom Resolution
 		m_custom_width = m_width = theApp.GetConfigI("resx");
 		m_custom_height = m_height = theApp.GetConfigI("resy");
@@ -118,28 +97,33 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 #ifdef __LIBRETRO__
 void GSRendererHW::UpdateRendererOptions()
 {
-	
-	m_userhacks_align_sprite_X = option_value(BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE, KeyOptionBool::return_type);
-	m_userHacks_merge_sprite = option_value(BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE, KeyOptionBool::return_type);
-	int skipdraw_start = option_value(INT_PCSX2_OPT_USERHACK_SKIPDRAW_START, KeyOptionInt::return_type);
-	int skipdraw_layers = option_value(INT_PCSX2_OPT_USERHACK_SKIPDRAW_LAYERS, KeyOptionInt::return_type);
-	m_userhacks_skipdraw_offset = skipdraw_start;
-	m_userhacks_skipdraw = skipdraw_start + skipdraw_layers;
-	m_userHacks_HPO = option_value(INT_PCSX2_OPT_USERHACK_HALFPIXEL_OFFSET, KeyOptionInt::return_type);
-	m_userhacks_round_sprite_offset = option_value(INT_PCSX2_OPT_USERHACK_ROUND_SPRITE, KeyOptionInt::return_type);
-	m_userhacks_wildhack = option_value(BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET, KeyOptionBool::return_type);
-	m_userhacks_ts_half_bottom = option_value(INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX, KeyOptionInt::return_type);
-	m_userhacks_auto_flush = option_value(BOOL_PCSX2_OPT_USERHACK_AUTO_FLUSH, KeyOptionBool::return_type);
-	theApp.SetConfig("UserHacks_AutoFlush", m_userhacks_auto_flush);
-	theApp.SetConfig("UserHacks", true);
-	
+
 	theApp.SetConfig("MaxAnisotropy", option_value(INT_PCSX2_OPT_ANISOTROPIC_FILTER, KeyOptionInt::return_type));
 	theApp.SetConfig("filter", option_value(INT_PCSX2_OPT_TEXTURE_FILTERING, KeyOptionInt::return_type));
+	
 	m_fxaa = option_value(INT_PCSX2_OPT_FXAA, KeyOptionInt::return_type);
 	theApp.SetConfig("fxaa", m_fxaa);
 	m_interlace = option_value(INT_PCSX2_OPT_DEINTERLACING_MODE, KeyOptionInt::return_type);
 	theApp.SetConfig("interlace", m_interlace);
-	m_upscale_multiplier = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
+
+	m_upscale_multiplier				= option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
+	
+	m_userhacks_align_sprite_X			= option_value(BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE, KeyOptionBool::return_type);
+	m_userHacks_merge_sprite			= option_value(BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE, KeyOptionBool::return_type);
+	int skipdraw_start					= option_value(INT_PCSX2_OPT_USERHACK_SKIPDRAW_START, KeyOptionInt::return_type);
+	int skipdraw_layers					= option_value(INT_PCSX2_OPT_USERHACK_SKIPDRAW_LAYERS, KeyOptionInt::return_type);
+	m_userhacks_skipdraw_offset			= skipdraw_start;
+	m_userhacks_skipdraw				= skipdraw_start + skipdraw_layers;
+	m_userHacks_HPO						= option_value(INT_PCSX2_OPT_USERHACK_HALFPIXEL_OFFSET, KeyOptionInt::return_type);
+	m_userhacks_round_sprite_offset		= option_value(INT_PCSX2_OPT_USERHACK_ROUND_SPRITE, KeyOptionInt::return_type);
+	m_userhacks_wildhack				= option_value(BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET, KeyOptionBool::return_type);
+	m_userhacks_ts_half_bottom			= option_value(INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX, KeyOptionInt::return_type);
+	m_userhacks_auto_flush				= option_value(BOOL_PCSX2_OPT_USERHACK_AUTO_FLUSH, KeyOptionBool::return_type);
+
+	theApp.SetConfig("UserHacks_AutoFlush", m_userhacks_auto_flush);
+	theApp.SetConfig("UserHacks", true);
+	
+
 	if (m_upscale_multiplier == 1) { // hacks are only needed for upscaling issues.
 		m_userhacks_round_sprite_offset = 0;
 		m_userhacks_align_sprite_X = false;

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -85,10 +85,13 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 
 	m_upscale_multiplier = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
 	theApp.SetConfig("MaxAnisotropy", option_value(INT_PCSX2_OPT_ANISOTROPIC_FILTER, KeyOptionInt::return_type));
+	theApp.SetConfig("filter", option_value(INT_PCSX2_OPT_TEXTURE_FILTERING, KeyOptionInt::return_type));
 	m_fxaa = option_value(INT_PCSX2_OPT_FXAA, KeyOptionInt::return_type);
 	theApp.SetConfig("fxaa", m_fxaa);
 	m_interlace = option_value(INT_PCSX2_OPT_DEINTERLACING_MODE, KeyOptionInt::return_type);
 	theApp.SetConfig("interlace", m_interlace);
+
+	
 
 #endif
 	if (!m_upscale_multiplier) { //Custom Resolution
@@ -125,6 +128,7 @@ void GSRendererHW::UpdateRendererOptions()
 	theApp.SetConfig("UserHacks", true);
 	
 	theApp.SetConfig("MaxAnisotropy", option_value(INT_PCSX2_OPT_ANISOTROPIC_FILTER, KeyOptionInt::return_type));
+	theApp.SetConfig("filter", option_value(INT_PCSX2_OPT_TEXTURE_FILTERING, KeyOptionInt::return_type));
 	m_fxaa = option_value(INT_PCSX2_OPT_FXAA, KeyOptionInt::return_type);
 	theApp.SetConfig("fxaa", m_fxaa);
 	m_interlace = option_value(INT_PCSX2_OPT_DEINTERLACING_MODE, KeyOptionInt::return_type);


### PR DESCRIPTION
Added option for texture filtering, as requested in issue #63 
Closes #63 

Removed conditional code in option initialization to avoid external influences due to .ini SpeedHack flag
Closes #69

EDIT: Let's close also old issues already solved but not closed, so we get rid of them from backlog
PR #21 Closes #10 
PR #30 Closes #15 