### PR TITLE
Backport of pcsx2#3936 BIOSHLE: Use BIOS settings on fastboot

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -34,7 +34,7 @@ struct retro_core_option_definition option_defs[] = {
 
 	{"pcsx2_fastboot",
 	"System: Fast Boot",
-	"Bypass the intial BIOS logo, with the side effect that BIOS settings like the system language will not be applied. (Content restart required)",
+	"Bypass the intial BIOS logo. (Content restart required)",
 	{
 		{"disabled", NULL},
 		{"enabled", NULL},

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -69,14 +69,6 @@ static wxFileName bios_dir;
 static const char* FILENAME_SHARED_MEMCARD_8 = "Shared Memory Card (8 MB)";
 static const char* FILENAME_SHARED_MEMCARD_32 = "Shared Memory Card (32 MB)";
 
-/*
-std::string slot1_dir;
-std::string slot2_dir;
-std::string legacy_path1;
-std::string legacy_path2;
-*/
-
-
 wxFileName save_dir_root;
 
 wxFileName slot1_file;

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -258,6 +258,12 @@ static void cdvdWriteMAC(const u8* num)
 	setNvmData(num, 0, 8, offsetof(NVMLayout, mac));
 }
 
+
+void cdvdReadLanguageParams(u8* config)
+{
+	getNvmData(config, 0xF, 16, offsetof(NVMLayout, config1));
+}
+
 s32 cdvdReadConfig(u8* config)
 {
 	// make sure its in read mode

--- a/pcsx2/CDVD/CDVD.h
+++ b/pcsx2/CDVD/CDVD.h
@@ -138,6 +138,8 @@ struct cdvdStruct
 };
 
 
+extern void cdvdReadLanguageParams(u8* config);
+
 extern void cdvdReset();
 extern void cdvdVsync();
 extern void cdvdActionInterrupt();

--- a/pcsx2/R5900OpcodeTables.h
+++ b/pcsx2/R5900OpcodeTables.h
@@ -21,6 +21,8 @@ enum Syscall : u8
 {
 	SetGsCrt = 2,
 	SetVTLBRefillHandler = 13,
+	GetOSParamConfig = 75,
+	GetOSParamConfig2 = 111,
 	sysPrintOut = 117,
 	sceSifSetDma = 119,
 	Deci2Call = 124


### PR DESCRIPTION
Original Description:
>Should fix bad fonts when booting a game fast
>Selects correct language for games depending on your BIOS setting when using fast boot
>Stops games such as Guitar Hero 2 from crashing on fast boot.
>PR also now corrects timezones in games.


Fastboot can now be used as workaround to fix some games (e.g. broken textures in Burnout 3 as reported in #70) starting the game with the right language selected in BIOS

Closes #70 