### PR TITLE
Revert "Fixed the annoying zombie process after deinit"

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -378,8 +378,12 @@ void retro_init(void)
 
 void retro_deinit(void)
 {
+	/* FIXME: This is a workaround that resolves crashes on close content.
+	When closing the frontend, we end up with a zombie process because the
+	main thread tries to call vu1Thread.Cancel() within pcsx2's destructor
+	and it gets stuck waiting for a mutex that will never unlock */
 	vu1Thread.WaitVU();
-	vu1Thread.Cancel();
+	//vu1Thread.Cancel();
 
 	pcsx2->CleanupOnExit();
 	pcsx2->OnExit();


### PR DESCRIPTION
Reverts libretro/pcsx2#83

Unfortunately did not fix the zombie process issue for me (on Windows 10), but I encourage the author to explore this further since this is definitely singlehandedly the biggest issue so far with this core.