### PR TITLE
Get rid of upscale_multiplier loaded from ini + fix to m_nativeres flag

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -250,22 +250,6 @@ void retro_init(void)
 	}
 
 
-	// instantiate the pcsx2 app and so some things on it
-
-	//pcsx2 = new Pcsx2App;
-	//wxApp::SetInstance(pcsx2);
-	pcsx2 = &wxGetApp();
-	#if 0
-		int argc = 0;
-		pcsx2->Initialize(argc, (wchar_t**)nullptr);
-		wxModule::RegisterModules();
-		wxModule::InitializeModules();
-	#endif
-	InitCPUTicks();
-	pxDoOutOfMemory = SysOutOfMemory_EmergencyResponse;
-	g_Conf = std::make_unique<AppConfig>();
-
-
 	// get the BIOS available and fill the option
 
 	bios_dir = Path::Combine(system, "pcsx2/bios");
@@ -303,6 +287,20 @@ void retro_init(void)
 	libretro_set_core_options(environ_cb);
 	option_upscale_mult = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
 
+	// instantiate the pcsx2 app and so some things on it
+
+	//pcsx2 = new Pcsx2App;
+	//wxApp::SetInstance(pcsx2);
+	pcsx2 = &wxGetApp();
+#if 0
+	int argc = 0;
+	pcsx2->Initialize(argc, (wchar_t**)nullptr);
+	wxModule::RegisterModules();
+	wxModule::InitializeModules();
+#endif
+	InitCPUTicks();
+	pxDoOutOfMemory = SysOutOfMemory_EmergencyResponse;
+	g_Conf = std::make_unique<AppConfig>();
 
 	// some other stuffs about pcsx2
 

--- a/plugins/GSdx/GSState.cpp
+++ b/plugins/GSdx/GSState.cpp
@@ -23,6 +23,7 @@
 #include "GSState.h"
 #include "GSdx.h"
 #include "GSUtil.h"
+#include "options_tools.h"
 
 //#define Offset_ST  // Fixes Persona3 mini map alignment which is off even in software rendering
 
@@ -47,7 +48,7 @@ GSState::GSState()
 {
 	// m_nativeres seems to be a hack. Unfortunately it impacts draw call number which make debug painful in the replayer.
 	// Let's keep it disabled to ease debug.
-	m_nativeres             = theApp.GetConfigI("upscale_multiplier") == 1;
+	m_nativeres             =  option_upscale_mult == 1;
 	m_mipmap                = theApp.GetConfigI("mipmap");
 	m_NTSC_Saturation       = theApp.GetConfigB("NTSC_Saturation");
 	m_clut_load_before_draw = theApp.GetConfigB("clut_load_before_draw");

--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -26,6 +26,7 @@
 #include "resource.h"
 #include <fstream>
 #include <VersionHelpers.h>
+#include "options_tools.h"
 
 GSDevice11::GSDevice11()
 {
@@ -41,7 +42,7 @@ GSDevice11::GSDevice11()
 	m_state.bf = -1;
 
 	m_mipmap = theApp.GetConfigI("mipmap");
-	m_upscale_multiplier = theApp.GetConfigI("upscale_multiplier");
+	m_upscale_multiplier = option_upscale_mult;
 	
 	const BiFiltering nearest_filter = static_cast<BiFiltering>(theApp.GetConfigI("filter"));
 	const int aniso_level = theApp.GetConfigI("MaxAnisotropy");

--- a/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSDeviceOGL.cpp
@@ -25,6 +25,7 @@
 #include "GLState.h"
 #include "GSUtil.h"
 #include <fstream>
+#include "options_tools.h"
 
 //#define ONLY_LINES
 
@@ -300,7 +301,7 @@ bool GSDeviceOGL::Create(const std::shared_ptr<GSWnd> &wnd)
 		// Upload once and forget about it.
 		// Use value of 1 when upscale multiplier is 0 for ScalingFactor,
 		// this is to avoid doing math with 0 in shader. It helps custom res be less broken.
-		m_misc_cb_cache.ScalingFactor = GSVector4i(std::max(1, theApp.GetConfigI("upscale_multiplier")));
+		m_misc_cb_cache.ScalingFactor = GSVector4i(std::max(1, option_upscale_mult));
 		m_convert.cb->cache_upload(&m_misc_cb_cache);
 
 		theApp.LoadResource(IDR_CONVERT_GLSL, shader);


### PR DESCRIPTION
Checked the code If there was some other calls which read the value from ini, and I found 2 more. Fixed that so now read the cached value instead.

There are good chances that these calls was the culprit of the problem #91 

@bslenul can you please test this? Thanks!