### PR TITLE
fix linking on Linux

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -634,7 +634,7 @@ set(pcsx2FinalLibs
 )
 
 if(BUILTIN_GS)
-    set(pcsx2FinalLibs ${pcsx2FinalLibs} GSdx)
+    set(pcsx2FinalLibs GSdx ${pcsx2FinalLibs})
     if(MSVC)
        set(pcsx2FinalSources ${pcsx2FinalSources} ${CMAKE_SOURCE_DIR}/plugins/GSdx/GSdx.rc)
     endif()


### PR DESCRIPTION
better fix than using `-DCMAKE_LINK_WHAT_YOU_USE=TRUE` I think :p