### PR TITLE
"DualShock 2" as default device type and fix L1/R1 labels for player 2

### DIFF
--- a/plugins/onepad/onepad.cpp
+++ b/plugins/onepad/onepad.cpp
@@ -81,8 +81,8 @@ static struct retro_input_descriptor desc[] = {
 	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "Circle"},
 	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "Cross"},
 	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Square"},
-	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "L"},
-	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "R"},
+	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "L1"},
+	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "R1"},
 	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "L2"},
 	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, "R2"},
 	{1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3, "L3"},
@@ -108,7 +108,7 @@ void Init()
 {
 	environ_cb(RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &rumble);
 	static const struct retro_controller_description ds2_desc[] = {
-		{"DualShock 2", RETRO_DEVICE_ANALOG},
+		{"DualShock 2", RETRO_DEVICE_JOYPAD},
 	};
 
 	static const struct retro_controller_info ports[] = {


### PR DESCRIPTION
* Set "DualShock 2" as the default (and only) device type. There's no reason to have both "RetroPad" and "DualShock 2", it only adds confusion for the users. Tested in multiplayer in "007 - Nightfire" and no issue (analogs working fine, etc.).
* "L/R" labels replaced with "L1/R1" for player 2.