### PR TITLE
Backport - CHD: Fix parent search on windows PCSX2/pcsx2#4578

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -166,6 +166,17 @@ struct retro_core_option_definition option_defs[] = {
 	},
 	"0" },
 
+	{ INT_PCSX2_OPT_DITHERING,
+	 "Video: Dithering",
+	 "Disabling dithering can remove some noise and pixelate effects",
+	{
+		{"0", "Off"},
+		{"1", "Scaled"},
+		{"2", "Unscaled (default)"},
+		{NULL, NULL},
+	},
+	"2" },
+
 	{INT_PCSX2_OPT_TEXTURE_FILTERING,
 	"Video: Texture Filtering",
 	"Controls the texture filtering of the emulation "

--- a/libretro/options_enums.h
+++ b/libretro/options_enums.h
@@ -41,6 +41,7 @@
 #define INT_PCSX2_OPT_MIPMAPPING		 "pcsx2_mipmapping"
 #define INT_PCSX2_OPT_CLAMPING_MODE		 "pcsx2_clamping_mode"
 #define INT_PCSX2_OPT_ROUND_MODE		 "pcsx2_round_mode"
+#define INT_PCSX2_OPT_DITHERING		 "pcsx2_dithering"
 
 #define INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_X_HUNDREDS		"pcsx2_userhack_texture_offset_x_hundreds"
 #define INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_X_TENS			"pcsx2_userhack_texture_offset_x_tens"

--- a/pcsx2/CDVD/ChdFileReader.cpp
+++ b/pcsx2/CDVD/ChdFileReader.cpp
@@ -44,7 +44,7 @@ bool ChdFileReader::Open(const wxString &fileName)
         wxDir dir(dir_path);
         if (dir.IsOpened()) {
           wxString parent_fileName;
-          bool cont = dir.GetFirst(&parent_fileName, wxString("*.", wxfilename.GetExt()), wxDIR_FILES | wxDIR_HIDDEN);
+		  bool cont = dir.GetFirst(&parent_fileName, wxString("*.") + wxfilename.GetExt(), wxDIR_FILES | wxDIR_HIDDEN);
           while ( cont ) {
             parent_fileName = wxFileName(dir_path, parent_fileName).GetFullPath();
             if (chd_read_header(static_cast<const char*>(parent_fileName), parent_header) == CHDERR_NONE &&

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -54,6 +54,8 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	m_interlace = option_value(INT_PCSX2_OPT_DEINTERLACING_MODE, KeyOptionInt::return_type);
 	theApp.SetConfig("interlace", m_interlace);
 
+	m_dithering = option_value(INT_PCSX2_OPT_DITHERING, KeyOptionInt::return_type);
+
 	m_userhacks_enabled_gs_mem_clear = true;
 	m_userHacks_enabled_unscale_ptln = true;
 
@@ -89,6 +91,8 @@ GSRendererHW::GSRendererHW(GSTextureCache* tc)
 	m_userhacks_tcoffset	= m_userhacks_tcoffset_x < 0.0f || m_userhacks_tcoffset_y < 0.0f;
 
 
+	
+
 	if (!m_upscale_multiplier) { //Custom Resolution
 		m_custom_width = m_width = theApp.GetConfigI("resx");
 		m_custom_height = m_height = theApp.GetConfigI("resy");
@@ -119,6 +123,8 @@ void GSRendererHW::UpdateRendererOptions()
 	m_upscale_multiplier				= option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
 	option_upscale_mult = m_upscale_multiplier;
 	theApp.SetConfig("upscale_multiplier", m_upscale_multiplier);
+
+	m_dithering = option_value(INT_PCSX2_OPT_DITHERING, KeyOptionInt::return_type);
 	
 	m_userhacks_align_sprite_X			= option_value(BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE, KeyOptionBool::return_type);
 	m_userHacks_merge_sprite			= option_value(BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE, KeyOptionBool::return_type);


### PR DESCRIPTION
Backport of "CHD: Fix parent search on windows PCSX2/PCSX2#4578" and added option to manage dithering


Closes #108 