### PR TITLE
Revert of BiosFilename init line deletion

### DIFF
--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -108,6 +108,8 @@ void AppApplySettings()
 	g_Conf->Folders.Cheats.Mkdir();
 	g_Conf->Folders.CheatsWS.Mkdir();
 
+	g_Conf->EmuOptions.BiosFilename = g_Conf->FullpathToBios();
+
 	// Update the compression attribute on the Memcards folder.
 	// Memcards generally compress very well via NTFS compression.
 


### PR DESCRIPTION
This line maybe has been deleted by mistake,

should fix the issue #113 

To be tested

EDIT: Tested OK, close #113 