### PR TITLE
Typo preventing from building Debug version

### DIFF
--- a/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
+++ b/plugins/GSdx/Renderers/DX11/GSDevice11.cpp
@@ -436,7 +436,7 @@ void GSDevice11::AfterDraw()
 	while (_BitScanForward(&i, m_state.ps_sr_bitfield))
 	{
 #ifdef _DEBUG
-		log_cb(RETRO_LOG_WARNING, "Cleaning up copied texture on slot %i\n", i);
+		log_cb(RETRO_LOG_WARN, "Cleaning up copied texture on slot %i\n", i);
 #endif
 		Recycle(m_state.ps_sr_texture[i]);
 		PSSetShaderResource(i, NULL);


### PR DESCRIPTION
Although it crashes on load content for me:
```
retroarch_drmingw.exe caused an Access Violation at location 00007FFC5D64D33B in module pcsx2_libretro.dll Reading from location 0000000000000898.

AddrPC           Params
00007FFC5D64D33B 0000000000000880 00007FFC5D646EA9 0000004307BF3F58  pcsx2_libretro.dll!std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::size  [G:\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30037\include\xstring @ 3940]
  3938: 
  3939:     _NODISCARD _CONSTEXPR20_CONTAINER size_type size() const noexcept {
> 3940:         return _Mypair._Myval2._Mysize;
  3941:     }
  3942: 
00007FFC5D64C294 0000000000000880 00007FFC5E055080 0000004307BF5F50  pcsx2_libretro.dll!std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::empty  [G:\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30037\include\xstring @ 4019]
  4017: 
  4018:     _NODISCARD _CONSTEXPR20_CONTAINER bool empty() const noexcept {
> 4019:         return size() == 0;
  4020:     }
  4021: 
00007FFC5D64C357 0000000000000880 0000000000000000 CCCCCCCCCCCCCCCC  pcsx2_libretro.dll!wxString::empty  [G:\msys64\home\B-S\pcsx2\3rdparty\wxwidgets3.0\include\wx\string.h @ 1393]
  1391:   size_type max_size() const { return npos; }
  1392: 
> 1393:   bool empty() const { return m_impl.empty(); }
  1394: 
  1395:   // NB: these methods don't have a well-defined meaning in UTF-8 case
00007FFC5D78914B 0000000000000828 CCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCC  pcsx2_libretro.dll!wxFileName::IsDir  [G:\msys64\home\B-S\pcsx2\3rdparty\wxwidgets3.0\include\wx\filename.h @ 495]
   493: 
   494:     // Is this a file or directory (not necessarily an existing one)
>  495:     bool IsDir() const { return m_name.empty() && m_ext.empty(); }
   496: 
   497:     // various helpers
00007FFC5DE8657A 0000000000000828 0000004307BF4260 0000004307BF4120  pcsx2_libretro.dll!wxDirName::Combine  [G:\msys64\home\B-S\pcsx2\common\src\Utilities\PathUtils.cpp @ 28]
    26: wxFileName wxDirName::Combine(const wxFileName &right) const
    27: {
>   28:     pxAssertMsg(IsDir(), L"Warning: Malformed directory name detected during wxDirName concatenation.");
    29:     if (right.IsAbsolute())
    30:         return right;
00007FFC5D71155E 0000000000000828 0000004307BF4260 0000004307BF5738  pcsx2_libretro.dll!wxDirName::operator+  [G:\msys64\home\B-S\pcsx2\common\include\Utilities\Path.h @ 188]
   186:     wxFileName operator+(const wxFileName &right) const { return Combine(right); }
   187:     wxDirName operator+(const wxDirName &right) const { return Combine(right); }
>  188:     wxFileName operator+(const wxString &right) const { return Combine(wxFileName(right)); }
   189:     wxFileName operator+(const char *right) const { return Combine(wxFileName(fromUTF8(right))); }
   190: 
00007FFC5D9E80AC 0000004307BF5738 0000004307BF5788 0000004307BF56E0  pcsx2_libretro.dll!IsBIOS  [G:\msys64\home\B-S\pcsx2\pcsx2\ps2\BiosTools.cpp @ 323]
   321: bool IsBIOS(const wxString& filename, wxString& description)
   322: {
>  323: wxFileName Bios( g_Conf->Folders.Bios + filename );
   324: pxInputStream inway( filename, new wxFFileInputStream( filename ) );
   325: 
00007FFC5D63CDCA 0000000000000000 000001E3DF024280 00000000000000FF  pcsx2_libretro.dll!retro_init  [G:\msys64\home\B-S\pcsx2\libretro\main.cpp @ 261]
   259: {
   260: wxString description;
>  261: if (IsBIOS(bios_file, description)) {
   262: std::string log_bios = (std::string)description;
   263: bios_files.push_back((std::string)bios_file);
00007FF700A1C25C 000001E3DF024280 00007FF7019C2CE0 000001E300000000  retroarch_drmingw.exe!command_event_init_core  [G:/msys64/home/B-S/retroarch/retroarch.c @ 12771]
 12769:    video_driver_set_cached_frame_ptr(NULL);
 12770: 
>12771:    p_rarch->current_core.retro_init();
 12772:    p_rarch->current_core.inited          = true;
 12773: 
00007FF700A1F436 000001E30000002A 00007FF701A10920 00007FF70136B301  retroarch_drmingw.exe!command_event  [G:/msys64/home/B-S/retroarch/retroarch.c @ 14370]
 14368:          {
 14369:             enum rarch_core_type *type    = (enum rarch_core_type*)data;
>14370:             rarch_system_info_t *sys_info = &runloop_state.system;
 14371: 
 14372:             content_reset_savestate_backups();
00007FF700A4E376 000001E30000000B 0000004307BF8700 0000004307BF8700  retroarch_drmingw.exe!retroarch_main_init  [G:/msys64/home/B-S/retroarch/retroarch.c @ 36072]
 36070:          "audio driver", verbosity_enabled);
 36071:    video_driver_find_driver(p_rarch, settings,
>36072:          "video driver", verbosity_enabled);
 36073:    input_driver_find_driver(p_rarch, settings,
 36074:          "input driver", verbosity_enabled);
00007FF700A6D8B2 0000004307BF8880 00007FF7019E3338 00000000000022A8  retroarch_drmingw.exe!content_load  [G:/msys64/home/B-S/retroarch/tasks/task_content.c @ 1475]
  1473:    wrap_args->argv = rarch_argv_ptr;
  1474: 
> 1475:    success         = retroarch_main_init(wrap_args->argc, wrap_args->argv);
  1476: 
  1477:    for (i = 0; i < ARRAY_SIZE(argv_copy); i++)
00007FF700A6DF86 00007FF7019E3338 0000004307BFAAC0 0000004307BF8900  retroarch_drmingw.exe!command_event_cmd_exec  [G:/msys64/home/B-S/retroarch/tasks/task_content.c @ 1701]
  1699: 
  1700:       /* Loads content into currently selected core. */
> 1701:       if (!content_load(&content_info, p_content))
  1702:          return false;
  1703:       task_push_to_history_list(p_content, true, launched_from_cli, false);
00007FF700A6E6DA 0000004307BF8AC0 0000004307BFAAC0 0000000000000000  retroarch_drmingw.exe!task_push_load_content_from_playlist_from_menu  [G:/msys64/home/B-S/retroarch/tasks/task_content.c @ 1961]
  1959:     * > On targets that do not support dynamic core loading,
  1960:     *   command_event_cmd_exec() will fork a new instance */
> 1961:    if (!(ret = command_event_cmd_exec(p_content,
  1962:          fullpath, &content_ctx, false, &error_string)))
  1963:       goto end;
00007FF700D57B3C 0000004307BF8AC0 0000004307BFAAC0 0000000000000000  retroarch_drmingw.exe!default_action_ok_load_content_from_playlist_from_menu  [G:/msys64/home/B-S/retroarch/menu/cbs/menu_cbs_ok.c @ 2141]
  2139:    content_info.args                   = NULL;
  2140:    content_info.environ_get            = NULL;
> 2141:    if (!task_push_load_content_from_playlist_from_menu(
  2142:             _path, path, entry_label,
  2143:             &content_info,
00007FF700D58CE2 0000004307BFEBF8 0000004307BFECF7 0000000000000007  retroarch_drmingw.exe!action_ok_playlist_entry_collection  [G:/msys64/home/B-S/retroarch/menu/cbs/menu_cbs_ok.c @ 2517]
  2515:     * may be free()'d by above playlist_free() - but need
  2516:     * to pass NULL explicitly if label is empty */
> 2517:    return default_action_ok_load_content_from_playlist_from_menu(
  2518:          core_path, content_path, string_is_empty(content_label) ? NULL : content_label);
  2519: 
00007FF700A070AC 000001E3ED52D780 0000004307BFEBE0 0000000000000000  retroarch_drmingw.exe!generic_menu_entry_action  [G:/msys64/home/B-S/retroarch/retroarch.c @ 2573]
  2571:       case MENU_ACTION_OK:
  2572:          if (cbs && cbs->action_ok)
> 2573:             ret = cbs->action_ok(entry->path,
  2574:                   entry->label, entry->type, i, entry->entry_idx);
  2575:          break;
00007FF700CED019 000001E3ED52D780 0000004307BFEBE0 0000000000000000  retroarch_drmingw.exe!ozone_menu_entry_action  [G:/msys64/home/B-S/retroarch/menu/drivers/ozone/ozone.c @ 640]
   638: 
   639:    /* Call standard generic_menu_entry_action() function */
>  640:    return generic_menu_entry_action(userdata, entry_ptr,
   641:          new_selection, new_action);
   642: }
00007FF700A07ED6 0000004307BFEBE0 0000000000000000 0000000000000005  retroarch_drmingw.exe!menu_entry_action  [G:/msys64/home/B-S/retroarch/retroarch.c @ 2853]
  2851:    if (     p_rarch->menu_driver_ctx
  2852:          && p_rarch->menu_driver_ctx->entry_action)
> 2853:       return p_rarch->menu_driver_ctx->entry_action(
  2854:             p_rarch->menu_userdata, entry, i, action);
  2855:    return -1;
00007FF700A05EAC 00007FF7019C2CE0 00007FF7019DD330 00007FF7019E5570  retroarch_drmingw.exe!generic_menu_iterate  [G:/msys64/home/B-S/retroarch/retroarch.c @ 2155]
  2153:             entry.sublabel_enabled   = false;
  2154:             menu_entry_get(&entry, 0, selection, NULL, false);
> 2155:             ret                      = menu_entry_action(&entry,
  2156:                   selection, (enum menu_action)action);
  2157:             if (ret)
00007FF700A0B377 00007FF7019C2CE0 00007FF7019DD330 00007FF7019E5570  retroarch_drmingw.exe!menu_driver_iterate  [G:/msys64/home/B-S/retroarch/retroarch.c @ 4650]
  4648: {
  4649:    return (p_rarch->menu_driver_data &&
> 4650:          generic_menu_iterate(
  4651:             p_rarch,
  4652:             menu_st,
00007FF700A52A69 00007FF7019C2CE0 000001E3DF024280 0000000644146F48  retroarch_drmingw.exe!runloop_check_state  [G:/msys64/home/B-S/retroarch/retroarch.c @ 38355]
 38353:                }
 38354:             }
>38355:          }
 38356:       }
 38357: 
00007FF700A548FC 000001E3DF024280 00007FF7019C2CE0 0000004307BFFB40  retroarch_drmingw.exe!runloop_iterate  [G:/msys64/home/B-S/retroarch/retroarch.c @ 39057]
 39055:       bool audio_buf_active        = false;
 39056:       unsigned audio_buf_occupancy = 0;
>39057:       bool audio_buf_underrun      = false;
 39058: 
 39059:       if (!(runloop_state.paused       ||
00007FF700A21B50 0000000000000001 000001E3DEFFED20 0000000000000000  retroarch_drmingw.exe!rarch_main  [G:/msys64/home/B-S/retroarch/retroarch.c @ 15698]
 15696: 
 15697:    ui_companion_driver_init_first(p_rarch->configuration_settings,
>15698:          p_rarch);
 15699: 
 15700: #if !defined(HAVE_MAIN) || defined(HAVE_QT)
00007FF700C0718D 0000000000000001 000001E3DEFFED20 00007FF70187522E  retroarch_drmingw.exe!SDL_main  [G:/msys64/home/B-S/retroarch/ui/drivers/ui_qt.cpp @ 4318]
  4316: int main(int argc, char *argv[])
  4317: {
> 4318:    return rarch_main(argc, argv, NULL);
  4319: }
  4320: #endif
00007FF70113C2AA 0000000000000000 000000000000002E 00007FF701AD7318  retroarch_drmingw.exe!main_getcmdline
00007FF700A013C1 0000000000000000 0000000000000000 0000000000000000  retroarch_drmingw.exe!__tmainCRTStartup  [C:/_/M/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/crt/crtexe.c @ 321]
00007FF700A014D6 0000000000000000 0000000000000000 0000000000000000  retroarch_drmingw.exe!WinMainCRTStartup  [C:/_/M/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/crt/crtexe.c @ 176]
00007FFCEE917034 0000000000000000 0000000000000000 0000000000000000  KERNEL32.DLL!BaseThreadInitThunk
00007FFCEF642651 0000000000000000 0000000000000000 0000000000000000  ntdll.dll!RtlUserThreadStart
```