### PR TITLE
Fix debug build + switch positions for widescreen/60fps patches core options

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -134,9 +134,9 @@ struct retro_core_option_definition option_defs[] = {
 	},
 	"0"},
 
-	{BOOL_PCSX2_OPT_ENABLE_60FPS_PATCHES,
-	"Video: Enable 60fps Patches",
-	"Enables 60fps patches that allow certain games to run at higher framerates than the original framerate. NOTE: No guarantees about stability or game bugs, use at your own caution. (Content restart required)",
+	{BOOL_PCSX2_OPT_ENABLE_WIDESCREEN_PATCHES,
+	"Video: Enable Widescreen Patches",
+	"Enables widescreen patches that allow certain games to render in true 16:9 ratio without stretching the display. For the widescreen patches to display properly, the 'Aspect Ratio' option should be set to Widescreen (16:9). (Content restart required)",
 	{
 		{"disabled", NULL},
 		{"enabled", NULL},
@@ -144,9 +144,9 @@ struct retro_core_option_definition option_defs[] = {
 	},
 	"disabled"},
 
-	{BOOL_PCSX2_OPT_ENABLE_WIDESCREEN_PATCHES,
-	"Video: Enable Widescreen Patches",
-	"Enables widescreen patches that allow certain games to render in true 16:9 ratio without stretching the display. For the widescreen patches to display properly, the 'Aspect Ratio' option should be set to Widescreen (16:9). (Content restart required)",
+	{BOOL_PCSX2_OPT_ENABLE_60FPS_PATCHES,
+	"Video: Enable 60fps Patches",
+	"Enables 60fps patches that allow certain games to run at higher framerates than the original framerate. NOTE: No guarantees about stability or game bugs, use at your own caution. (Content restart required)",
 	{
 		{"disabled", NULL},
 		{"enabled", NULL},

--- a/plugins/GS/Renderers/DX11/GSRendererDX11.cpp
+++ b/plugins/GS/Renderers/DX11/GSRendererDX11.cpp
@@ -197,9 +197,9 @@ void GSRendererDX11::EmulateZbuffer()
 	// Minor optimization of a corner case (it allow to better emulate some alpha test effects)
 	if (m_om_dssel.ztst == ZTST_GEQUAL && m_vt.m_eq.z && v[0].XYZ.Z == max_z)
 	{
-#ifdef _DEBUG
-		log_cb(RETRO_LOG_DEBUG, "%d: Optimize Z test GEQUAL to ALWAYS (%s)\n", s_n, psm_str(m_context->ZBUF.PSM));
-#endif
+//#ifdef _DEBUG
+		//log_cb(RETRO_LOG_DEBUG, "%d: Optimize Z test GEQUAL to ALWAYS (%s)\n", s_n, psm_str(m_context->ZBUF.PSM));
+//#endif
 		m_om_dssel.ztst = ZTST_ALWAYS;
 	}
 }


### PR DESCRIPTION
* Fixes debug build by commenting the remaining `log_cb` thing from `GSRendererDX11.cpp`, or else it gives an "identifier not found" error during compilation.
* I'm nitpicking here but I feel like having the widescreen patches option right after the aspect ratio option makes more sense ;)