### PR TITLE
Restore the try/catch block in GSState.cpp

### DIFF
--- a/plugins/GS/GSState.cpp
+++ b/plugins/GS/GSState.cpp
@@ -1616,7 +1616,15 @@ void GSState::FlushPrim()
 
 			m_context->SaveReg();
 
-			Draw();
+			try {
+				Draw();
+			} catch (GSDXRecoverableError&) {
+				// could be an unsupported draw call
+			} catch (const std::bad_alloc& e) {
+				// Texture Out Of Memory
+				PurgePool();
+				fprintf(stderr, "GSDX OUT OF MEMORY\n");
+			}
 
 			m_context->RestoreReg();
 


### PR DESCRIPTION
It fixes partially #130, the game still crashes with fast boot ON.