### PR TITLE
[Logs] Removed uneeded curly braces and added a missing new line in 'GameDatabase.cpp'

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -54,10 +54,10 @@ std::string GameDatabaseSchema::GameEntry::memcardFiltersAsString() const
 bool GameDatabaseSchema::GameEntry::findPatch(const std::string crc, Patch& patch) const
 {
 	std::string crcLower = strToLower(crc);
-	log_cb(RETRO_LOG_INFO, "[GameDB] Searching for patch with CRC '{%s}'\n", crc.c_str());
+	log_cb(RETRO_LOG_INFO, "[GameDB] Searching for patch with CRC '%s'\n", crc.c_str());
 	if (patches.count(crcLower) == 1)
 	{
-		log_cb(RETRO_LOG_INFO, "[GameDB] Found patch with CRC '{%s}'\n", crc.c_str());
+		log_cb(RETRO_LOG_INFO, "[GameDB] Found patch with CRC '%s'\n", crc.c_str());
 		patch = patches.at(crcLower);
 		return true;
 	} else if (patches.count("default") == 1)
@@ -122,7 +122,7 @@ GameDatabaseSchema::GameEntry YamlGameDatabaseImpl::entryFromYaml(const std::str
 				gameEntry.gameFixes.push_back(fix);
 			} else
 			{
-				log_cb(RETRO_LOG_ERROR, "[GameDB] Invalid gamefix: '{%s}', specified for serial: '{%s}'. Dropping!", fix.c_str(), serial.c_str());
+				log_cb(RETRO_LOG_ERROR, "[GameDB] Invalid gamefix: '%s', specified for serial: '%s'. Dropping!\n", fix.c_str(), serial.c_str());
 			}
 		}
 
@@ -147,7 +147,7 @@ GameDatabaseSchema::GameEntry YamlGameDatabaseImpl::entryFromYaml(const std::str
 					gameEntry.speedHacks[speedHack] = entry.second.as<int>();
 				} else
 				{
-					log_cb(RETRO_LOG_ERROR, "[GameDB] Invalid speedhack: '{%s}', specified for serial: '{%s}'. Dropping!\n", speedHack.c_str(), serial.c_str());
+					log_cb(RETRO_LOG_ERROR, "[GameDB] Invalid speedhack: '%s', specified for serial: '%s'. Dropping!\n", speedHack.c_str(), serial.c_str());
 				}
 			}
 		}
@@ -175,11 +175,11 @@ GameDatabaseSchema::GameEntry YamlGameDatabaseImpl::entryFromYaml(const std::str
 		}
 	} catch (const YAML::RepresentationException& e)
 	{
-		log_cb(RETRO_LOG_ERROR, "[GameDB] Invalid GameDB syntax detected on serial: '{%s}'. Error Details - {%s}\n", serial.c_str(), e.msg.c_str());
+		log_cb(RETRO_LOG_ERROR, "[GameDB] Invalid GameDB syntax detected on serial: '%s'. Error Details - %s\n", serial.c_str(), e.msg.c_str());
 		gameEntry.isValid = false;
 	} catch (const std::exception& e)
 	{
-		log_cb(RETRO_LOG_ERROR, "[GameDB] Unexpected error occurred when reading serial: '{%s}'. Error Details - {%s}\n", serial.c_str(), e.what());
+		log_cb(RETRO_LOG_ERROR, "[GameDB] Unexpected error occurred when reading serial: '%s'. Error Details - %s\n", serial.c_str(), e.what());
 		gameEntry.isValid = false;
 	}
 	return gameEntry;
@@ -188,14 +188,14 @@ GameDatabaseSchema::GameEntry YamlGameDatabaseImpl::entryFromYaml(const std::str
 GameDatabaseSchema::GameEntry YamlGameDatabaseImpl::findGame(const std::string serial)
 {
 	std::string serialLower = strToLower(serial);
-	log_cb(RETRO_LOG_INFO, "[GameDB] Searching for '{%s}' in GameDB\n", serialLower.c_str());
+	log_cb(RETRO_LOG_INFO, "[GameDB] Searching for '%s' in GameDB\n", serialLower.c_str());
 	if (gameDb.count(serialLower) == 1)
 	{
-		log_cb(RETRO_LOG_INFO, "[GameDB] Found '{%s}' in GameDB\n", serialLower.c_str());
+		log_cb(RETRO_LOG_INFO, "[GameDB] Found '%s' in GameDB\n", serialLower.c_str());
 		return gameDb[serialLower];
 	}
 
-	log_cb(RETRO_LOG_ERROR, "[GameDB] Could not find '{%s}' in GameDB\n", serialLower.c_str());
+	log_cb(RETRO_LOG_ERROR, "[GameDB] Could not find '%s' in GameDB\n", serialLower.c_str());
 	GameDatabaseSchema::GameEntry entry;
 	entry.isValid = false;
 	return entry;
@@ -231,18 +231,18 @@ bool YamlGameDatabaseImpl::initDatabase(std::istream& stream)
 				std::string serial = strToLower(entry.first.as<std::string>());
 				if (gameDb.count(serial) == 1)
 				{
-					log_cb(RETRO_LOG_ERROR, "[GameDB] Duplicate serial '{%s}' found in GameDB. Skipping, Serials are case-insensitive!\n", serial.c_str());
+					log_cb(RETRO_LOG_ERROR, "[GameDB] Duplicate serial '%s' found in GameDB. Skipping, Serials are case-insensitive!\n", serial.c_str());
 					continue;
 				}
 				gameDb[serial] = entryFromYaml(serial, entry.second);
 			} catch (const YAML::RepresentationException& e)
 			{
-				log_cb(RETRO_LOG_ERROR, "[GameDB] Invalid GameDB syntax detected. Error Details - {%s}\n", e.msg.c_str());
+				log_cb(RETRO_LOG_ERROR, "[GameDB] Invalid GameDB syntax detected. Error Details - %s\n", e.msg.c_str());
 			}
 		}
 	} catch (const std::exception& e)
 	{
-		log_cb(RETRO_LOG_ERROR, "[GameDB] Error occured when initializing GameDB: {%s}\n", e.what());
+		log_cb(RETRO_LOG_ERROR, "[GameDB] Error occured when initializing GameDB: %s\n", e.what());
 		return false;
 	}
 


### PR DESCRIPTION
Currently it looks like that in logs:
```
[libretro ERROR] [GameDB] Invalid gamefix: '{VUKickstartHack}', specified for serial: '{scaj-25047}'. Dropping![libretro ERROR] [GameDB] Invalid gamefix: '{VUKickstartHack}', specified for serial: '{slaj-25047}'. Dropping![libretro ERROR] [GameDB] Invalid gamefix: '{VUKickstartHack}', specified for serial: '{slka-25225}'. Dropping![libretro ERROR] [GameDB] Invalid gamefix: '{VUKickstartHack}', specified for serial: '{slpm-65526}'. Dropping![libretro ERROR] [GameDB] Invalid gamefix: '{VUKickstartHack}', specified for serial: '{slpm-66207}'. Dropping![libretro INFO] [GameDB] 10372 games on record
[libretro INFO] [GameDB] Searching for '{slus-20909}' in GameDB
[libretro INFO] [GameDB] Found '{slus-20909}' in GameDB
[libretro INFO] [GameDB] Searching for patch with CRC '{8cfab4ea}'
```

Now:
```
[libretro ERROR] [GameDB] Invalid gamefix: 'VUKickstartHack', specified for serial: 'scaj-25047'. Dropping!
[libretro ERROR] [GameDB] Invalid gamefix: 'VUKickstartHack', specified for serial: 'slaj-25047'. Dropping!
[libretro ERROR] [GameDB] Invalid gamefix: 'VUKickstartHack', specified for serial: 'slka-25225'. Dropping!
[libretro ERROR] [GameDB] Invalid gamefix: 'VUKickstartHack', specified for serial: 'slpm-65526'. Dropping!
[libretro ERROR] [GameDB] Invalid gamefix: 'VUKickstartHack', specified for serial: 'slpm-66207'. Dropping!
[libretro INFO] [GameDB] 10372 games on record
[libretro INFO] [GameDB] Searching for 'slus-20909' in GameDB
[libretro INFO] [GameDB] Found 'slus-20909' in GameDB
[libretro INFO] [GameDB] Searching for patch with CRC '8cfab4ea'
```