### PR TITLE
 Fixed problem which prevented to load selected memory cards when starting core without content

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -272,6 +272,14 @@ void retro_init(void)
 			}
 	}
 
+	// check if there are bios file in the bios folders, otherwise terminates with a explicit log message
+
+	if (bios_files.size() == 0) {
+		std::string checked_path = bios_dir.GetFullPath().ToStdString();
+		log_cb(RETRO_LOG_ERROR, "Could not find valid BIOS files! \n");
+		log_cb(RETRO_LOG_ERROR, "Please provide required BIOS file in %s folder \n", checked_path.c_str());
+		return;
+	}
 
 
 	for (retro_core_option_definition& def : option_defs)

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -628,6 +628,78 @@ bool retro_load_game(const struct retro_game_info* game)
 	DiskControl::eject_state = false;
 
 
+	// set up memcard on slot 1
+
+	if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "empty") == 0)
+	{
+		// slot empty
+		g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_None;
+		g_Conf->Mcd[0].Enabled = false;
+	}
+	else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "shared8") == 0
+		|| strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "shared32") == 0)
+	{
+		// Shared Memcards
+		g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[0].Enabled = true;
+		g_Conf->Mcd[0].Filename = slot1_file;
+
+	}
+	else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "legacy") == 0)
+	{
+		// legacy
+		g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[0].Enabled = true;
+		g_Conf->Mcd[0].Filename = legacy_memcard1;
+	}
+	else
+	{
+		// User imported memcards
+		wxFileName user_memcard;
+		user_memcard.Assign(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type));
+
+		g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[0].Enabled = true;
+		g_Conf->Mcd[0].Filename = user_memcard;
+	}
+
+
+	// set up memcard on slot 2
+
+	if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "empty") == 0)
+	{
+		// slot empty
+		g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_None;
+		g_Conf->Mcd[1].Enabled = false;
+	}
+	else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "shared8") == 0
+		|| strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "shared32") == 0)
+	{
+		// Shared Memcards
+		g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[1].Enabled = true;
+		g_Conf->Mcd[1].Filename = slot2_file;
+	}
+	else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "legacy") == 0)
+	{
+		// legacy
+		g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[1].Enabled = true;
+		g_Conf->Mcd[1].Filename = legacy_memcard2;
+	}
+	else
+	{
+		// User imported memcards
+		wxFileName user_memcard;
+		user_memcard.Assign(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type));
+
+		g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[1].Enabled = true;
+		g_Conf->Mcd[1].Filename = user_memcard;
+
+	}
+
+
 	if (game)
 	{
 
@@ -679,79 +751,6 @@ bool retro_load_game(const struct retro_game_info* game)
 			g_Conf->CdvdSource = CDVD_SourceType::Iso;
 			g_Conf->CurrentIso = game_paths[0];
 
-			// set up memcard on slot 1
-			if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "empty") == 0)
-			{
-				// slot empty
-				g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_None;
-				g_Conf->Mcd[0].Enabled = false;
-			}
-			else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "shared8") == 0 
-					|| strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "shared32") == 0)
-			{
-				// Shared Memcards
-				g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[0].Enabled = true;
-				g_Conf->Mcd[0].Filename = slot1_file;
-
-			}
-			else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "legacy") == 0)
-			{
-				// legacy
-				g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[0].Enabled = true;
-				g_Conf->Mcd[0].Filename = legacy_memcard1;
-			}
-			else
-			{
-				// User imported memcards
-				wxFileName user_memcard;
-				user_memcard.Assign(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type));
-
-				g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[0].Enabled = true;
-				g_Conf->Mcd[0].Filename = user_memcard;
-			}
-
-
-
-
-			// set up memcard on slot 2
-
-
-			if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "empty") == 0)
-			{
-				// slot empty
-				g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_None;
-				g_Conf->Mcd[1].Enabled = false;
-			}
-			else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "shared8") == 0 
-					|| strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "shared32") == 0)
-			{
-				// Shared Memcards
-				g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[1].Enabled = true;
-				g_Conf->Mcd[1].Filename = slot2_file;
-			}
-			else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "legacy") == 0)
-			{
-				// legacy
-				g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[1].Enabled = true;
-				g_Conf->Mcd[1].Filename = legacy_memcard2;
-			}
-			else
-			{
-				// User imported memcards
-				wxFileName user_memcard;
-				user_memcard.Assign(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type));
-
-				g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[1].Enabled = true;
-				g_Conf->Mcd[1].Filename = user_memcard;
-
-			}
-
 
 			if (!option_value(BOOL_PCSX2_OPT_BOOT_TO_BIOS, KeyOptionBool::return_type))
 			{
@@ -774,7 +773,7 @@ bool retro_load_game(const struct retro_game_info* game)
 	}
 	else
 	{
-		log_cb(RETRO_LOG_INFO, "Entrerning BIOS Menu.....\n");
+		log_cb(RETRO_LOG_INFO, "Enterning BIOS Menu.....\n");
 		g_Conf->EmuOptions.UseBOOT2Injection = option_value(BOOL_PCSX2_OPT_FASTBOOT, KeyOptionBool::return_type);
 		g_Conf->CdvdSource = CDVD_SourceType::NoDisc;
 		g_Conf->CurrentIso = "";

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -306,8 +306,6 @@ void retro_init(void)
 
 	option_upscale_mult = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
 
-	log_cb(RETRO_LOG_DEBUG, "let's generate teh bios path \n");
-
 	wxFileName f_bios;
 	f_bios.Assign(option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type));
 

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -264,12 +264,15 @@ void retro_init(void)
 	{
 			wxString description;
 			if (IsBIOSlite(bios_file, description)) {
-				std::string log_bios = (std::string)description;				
-				bios_files.push_back((std::string)bios_file);
+				std::string log_bios = (std::string)description;
+				wxFileName f;
+				f.Assign(bios_file);
+				bios_files.push_back((std::string)f.GetFullName());
 				bios_files.push_back((std::string)description);
 			}
 	}
-	
+
+
 
 	for (retro_core_option_definition& def : option_defs)
 	{
@@ -286,12 +289,23 @@ void retro_init(void)
 		break;
 	}
 
+
 	// loads the options structure to the frontend
 
 	libretro_set_core_options(environ_cb);
-	option_upscale_mult = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
-	sel_bios_path = option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type);
 
+	// start init some core settings
+
+	option_upscale_mult = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
+
+	log_cb(RETRO_LOG_DEBUG, "let's generate teh bios path \n");
+
+	wxFileName f_bios;
+	f_bios.Assign(option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type));
+
+	f_bios = wxFileName(bios_dir.GetFullPath(), option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type));
+	sel_bios_path = f_bios.GetFullPath().ToStdString();
+	
 	// instantiate the pcsx2 app and so some things on it
 	pcsx2 = &wxGetApp();
 	pxDoOutOfMemory = SysOutOfMemory_EmergencyResponse;
@@ -584,7 +598,7 @@ bool retro_load_game(const struct retro_game_info* game)
 
 	ResetContentStuffs();
 
-	const char* selected_bios = option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type);
+	const char* selected_bios = sel_bios_path.c_str();
 	if (selected_bios == NULL)
 	{
 		log_cb(RETRO_LOG_ERROR, "Could not find any valid PS2 Bios File in %s\n", (const char*)bios_dir.GetFullPath());


### PR DESCRIPTION
Fixes also the default memory cards Mcd001 and Mcd002 which was created in the Retroarch root folder as side effect of the issue.

close #156 