### PR TITLE
Fixed problem of chrashes on nvm/mec creation with fastboot enabled

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -272,6 +272,14 @@ void retro_init(void)
 			}
 	}
 
+	// check if there are bios file in the bios folders, otherwise terminates with a explicit log message
+
+	if (bios_files.size() == 0) {
+		std::string checked_path = bios_dir.GetFullPath().ToStdString();
+		log_cb(RETRO_LOG_ERROR, "Could not find valid BIOS files! \n");
+		log_cb(RETRO_LOG_ERROR, "Please provide required BIOS file in %s folder \n", checked_path.c_str());
+		return;
+	}
 
 
 	for (retro_core_option_definition& def : option_defs)

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -628,6 +628,78 @@ bool retro_load_game(const struct retro_game_info* game)
 	DiskControl::eject_state = false;
 
 
+	// set up memcard on slot 1
+
+	if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "empty") == 0)
+	{
+		// slot empty
+		g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_None;
+		g_Conf->Mcd[0].Enabled = false;
+	}
+	else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "shared8") == 0
+		|| strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "shared32") == 0)
+	{
+		// Shared Memcards
+		g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[0].Enabled = true;
+		g_Conf->Mcd[0].Filename = slot1_file;
+
+	}
+	else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "legacy") == 0)
+	{
+		// legacy
+		g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[0].Enabled = true;
+		g_Conf->Mcd[0].Filename = legacy_memcard1;
+	}
+	else
+	{
+		// User imported memcards
+		wxFileName user_memcard;
+		user_memcard.Assign(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type));
+
+		g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[0].Enabled = true;
+		g_Conf->Mcd[0].Filename = user_memcard;
+	}
+
+
+	// set up memcard on slot 2
+
+	if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "empty") == 0)
+	{
+		// slot empty
+		g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_None;
+		g_Conf->Mcd[1].Enabled = false;
+	}
+	else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "shared8") == 0
+		|| strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "shared32") == 0)
+	{
+		// Shared Memcards
+		g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[1].Enabled = true;
+		g_Conf->Mcd[1].Filename = slot2_file;
+	}
+	else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "legacy") == 0)
+	{
+		// legacy
+		g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[1].Enabled = true;
+		g_Conf->Mcd[1].Filename = legacy_memcard2;
+	}
+	else
+	{
+		// User imported memcards
+		wxFileName user_memcard;
+		user_memcard.Assign(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type));
+
+		g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
+		g_Conf->Mcd[1].Enabled = true;
+		g_Conf->Mcd[1].Filename = user_memcard;
+
+	}
+
+
 	if (game)
 	{
 
@@ -679,79 +751,6 @@ bool retro_load_game(const struct retro_game_info* game)
 			g_Conf->CdvdSource = CDVD_SourceType::Iso;
 			g_Conf->CurrentIso = game_paths[0];
 
-			// set up memcard on slot 1
-			if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "empty") == 0)
-			{
-				// slot empty
-				g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_None;
-				g_Conf->Mcd[0].Enabled = false;
-			}
-			else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "shared8") == 0 
-					|| strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "shared32") == 0)
-			{
-				// Shared Memcards
-				g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[0].Enabled = true;
-				g_Conf->Mcd[0].Filename = slot1_file;
-
-			}
-			else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type), "legacy") == 0)
-			{
-				// legacy
-				g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[0].Enabled = true;
-				g_Conf->Mcd[0].Filename = legacy_memcard1;
-			}
-			else
-			{
-				// User imported memcards
-				wxFileName user_memcard;
-				user_memcard.Assign(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_1, KeyOptionString::return_type));
-
-				g_Conf->Mcd[0].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[0].Enabled = true;
-				g_Conf->Mcd[0].Filename = user_memcard;
-			}
-
-
-
-
-			// set up memcard on slot 2
-
-
-			if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "empty") == 0)
-			{
-				// slot empty
-				g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_None;
-				g_Conf->Mcd[1].Enabled = false;
-			}
-			else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "shared8") == 0 
-					|| strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "shared32") == 0)
-			{
-				// Shared Memcards
-				g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[1].Enabled = true;
-				g_Conf->Mcd[1].Filename = slot2_file;
-			}
-			else if (strcmp(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type), "legacy") == 0)
-			{
-				// legacy
-				g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[1].Enabled = true;
-				g_Conf->Mcd[1].Filename = legacy_memcard2;
-			}
-			else
-			{
-				// User imported memcards
-				wxFileName user_memcard;
-				user_memcard.Assign(option_value(STRING_PCSX2_OPT_MEMCARD_SLOT_2, KeyOptionString::return_type));
-
-				g_Conf->Mcd[1].Type = MemoryCardType::MemoryCard_File;
-				g_Conf->Mcd[1].Enabled = true;
-				g_Conf->Mcd[1].Filename = user_memcard;
-
-			}
-
 
 			if (!option_value(BOOL_PCSX2_OPT_BOOT_TO_BIOS, KeyOptionBool::return_type))
 			{
@@ -774,7 +773,7 @@ bool retro_load_game(const struct retro_game_info* game)
 	}
 	else
 	{
-		log_cb(RETRO_LOG_INFO, "Entrerning BIOS Menu.....\n");
+		log_cb(RETRO_LOG_INFO, "Enterning BIOS Menu.....\n");
 		g_Conf->EmuOptions.UseBOOT2Injection = option_value(BOOL_PCSX2_OPT_FASTBOOT, KeyOptionBool::return_type);
 		g_Conf->CdvdSource = CDVD_SourceType::NoDisc;
 		g_Conf->CurrentIso = "";

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -760,7 +760,7 @@ bool retro_load_game(const struct retro_game_info* game)
 				// we enter here in the bios, so we have the correct memcards loaded
 				log_cb(RETRO_LOG_INFO, "Entrerning BIOS Menu.....\n");
 				RetroMessager::Notification("Boot to BIOS enabled", true);
-				g_Conf->EmuOptions.UseBOOT2Injection = option_value(BOOL_PCSX2_OPT_FASTBOOT, KeyOptionBool::return_type);
+				g_Conf->EmuOptions.UseBOOT2Injection = false;
 				g_Conf->CdvdSource = CDVD_SourceType::NoDisc;
 				g_Conf->CurrentIso = "";
 				pcsx2->SysExecute(g_Conf->CdvdSource);
@@ -772,7 +772,7 @@ bool retro_load_game(const struct retro_game_info* game)
 	else
 	{
 		log_cb(RETRO_LOG_INFO, "Enterning BIOS Menu.....\n");
-		g_Conf->EmuOptions.UseBOOT2Injection = option_value(BOOL_PCSX2_OPT_FASTBOOT, KeyOptionBool::return_type);
+		g_Conf->EmuOptions.UseBOOT2Injection = false;
 		g_Conf->CdvdSource = CDVD_SourceType::NoDisc;
 		g_Conf->CurrentIso = "";
 		pcsx2->SysExecute(g_Conf->CdvdSource);

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -614,6 +614,22 @@ bool retro_load_game(const struct retro_game_info* game)
 		log_cb(RETRO_LOG_INFO, "Loading selected BIOS:  %s\n", selected_bios);
 
 
+	// we check if nvm file exists, if not it means that it's a new bios.
+	// in this case whe bypass the fastboot option, forcing to enter the bios first run setup
+
+	wxFileName nvmFileCheck;
+	nvmFileCheck.Assign(sel_bios_path);
+	nvmFileCheck.SetExt("nvm");
+	
+	bool fastboot_option = option_value(BOOL_PCSX2_OPT_FASTBOOT, KeyOptionBool::return_type);
+
+	if (! nvmFileCheck.FileExists()) {
+		fastboot_option = false;
+	}
+
+
+
+
 	const char* system = nullptr;
 	environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system);
 
@@ -702,7 +718,7 @@ bool retro_load_game(const struct retro_game_info* game)
 	{
 
 		LanguageInjector::Inject(
-				(std::string)option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type),
+				sel_bios_path,
 				option_value(STRING_PCSX2_OPT_SYSTEM_LANGUAGE, KeyOptionString::return_type)
 				);
 
@@ -745,7 +761,7 @@ bool retro_load_game(const struct retro_game_info* game)
 		else
 		{	
 
-			g_Conf->EmuOptions.UseBOOT2Injection = option_value(BOOL_PCSX2_OPT_FASTBOOT, KeyOptionBool::return_type);
+			g_Conf->EmuOptions.UseBOOT2Injection = fastboot_option;
 			g_Conf->CdvdSource = CDVD_SourceType::Iso;
 			g_Conf->CurrentIso = game_paths[0];
 

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -306,8 +306,6 @@ void retro_init(void)
 
 	option_upscale_mult = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
 
-	log_cb(RETRO_LOG_DEBUG, "let's generate teh bios path \n");
-
 	wxFileName f_bios;
 	f_bios.Assign(option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type));
 

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -264,12 +264,15 @@ void retro_init(void)
 	{
 			wxString description;
 			if (IsBIOSlite(bios_file, description)) {
-				std::string log_bios = (std::string)description;				
-				bios_files.push_back((std::string)bios_file);
+				std::string log_bios = (std::string)description;
+				wxFileName f;
+				f.Assign(bios_file);
+				bios_files.push_back((std::string)f.GetFullName());
 				bios_files.push_back((std::string)description);
 			}
 	}
-	
+
+
 
 	for (retro_core_option_definition& def : option_defs)
 	{
@@ -286,12 +289,23 @@ void retro_init(void)
 		break;
 	}
 
+
 	// loads the options structure to the frontend
 
 	libretro_set_core_options(environ_cb);
-	option_upscale_mult = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
-	sel_bios_path = option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type);
 
+	// start init some core settings
+
+	option_upscale_mult = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
+
+	log_cb(RETRO_LOG_DEBUG, "let's generate teh bios path \n");
+
+	wxFileName f_bios;
+	f_bios.Assign(option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type));
+
+	f_bios = wxFileName(bios_dir.GetFullPath(), option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type));
+	sel_bios_path = f_bios.GetFullPath().ToStdString();
+	
 	// instantiate the pcsx2 app and so some things on it
 	pcsx2 = &wxGetApp();
 	pxDoOutOfMemory = SysOutOfMemory_EmergencyResponse;
@@ -584,7 +598,7 @@ bool retro_load_game(const struct retro_game_info* game)
 
 	ResetContentStuffs();
 
-	const char* selected_bios = option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type);
+	const char* selected_bios = sel_bios_path.c_str();
 	if (selected_bios == NULL)
 	{
 		log_cb(RETRO_LOG_ERROR, "Could not find any valid PS2 Bios File in %s\n", (const char*)bios_dir.GetFullPath());

--- a/resources/GameIndex.yaml
+++ b/resources/GameIndex.yaml
@@ -1015,6 +1015,54 @@ SCAJ-30010:
 SCAJ-30011:
   name: "God of War II"
   region: "NTSC-E"
+SCCS-40002:
+  name: "Devil May Cry 2 - Disc 1"
+  region: "NTSC-C"
+SCCS-40003:
+  name: "Devil May Cry 2 - Disc 2"
+  region: "NTSC-C"
+SCCS-40005:
+  name: "ICO"
+  region: "NTSC-C"
+  clampModes:
+    eeClampMode: 2  # Otherwise freezes in various spots, check full intro.
+    vuClampMode: 1  # Otherwise camera gets stuck off the player in various spots.
+SCCS-40006:
+  name: "Shin Sangoku Musou 2"
+  region: "NTSC-C"
+SCCS-40007:
+  name: "Arc the Lad: Seirei no Tasogare"
+  region: "NTSC-C"
+SCCS-40009:
+  name: "Dragon Ball Z 2"
+  region: "NTSC-C"
+SCCS-40010:
+  name: "Super Puzzle Bobble 2"
+  region: "NTSC-C"
+SCCS-40011:
+  name: "Armored Core 2: Another Age"
+  region: "NTSC-C"
+SCCS-40014:
+  name: "World Soccer Winning Eleven 7: International"
+  region: "NTSC-C"
+SCCS-40015:
+  name: "Viorate no Atelier: Gramnad no Renkinjutsushi 2"
+  region: "NTSC-C"
+SCCS-40016:
+  name: "Ape Escape: Pumped & Primed"
+  region: "NTSC-C"
+SCCS-40017:
+  name: "EyeToy: Play"
+  region: "NTSC-C"
+SCCS-40018:
+  name: "Saru EyeToy: Oosawagi! Ukkiuki Game Tenkomori!!"
+  region: "NTSC-C"
+SCCS-40019:
+  name: "Formula One 04"
+  region: "NTSC-C"
+SCCS-40022:
+  name: "World Soccer Winning Eleven 8: Asia Championship"
+  region: "NTSC-C"
 SCED-50041:
   name: "Tekken Tag Tournament [Demo]"
   region: "PAL-E"


### PR DESCRIPTION

Fixed the problem (issue #163 ) forcing the user to enter the bios "first run" configurator also when fastboot is enabled.

This is done by checking if nvm exists, if not it bypass the fastboot setting and enters the bios config, creating nvm and mec file. From next boot fast boot is applied again.

This pr solves also a bios path problem on the language injector, introduced by #155 