### PR TITLE
Independent clamping and round modes for EE/FPU and VUs

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -394,8 +394,8 @@ struct retro_core_option_definition option_defs[] = {
 	{
 		{"0", "None"},
 		{"1", "Normal (default)"},
-		{"2", "Extra + Preserve Sign"},
-		{"3", "Full"},
+		{"2", "Extra"},
+		{"3", "Extra + Preserve Sign"},
 		{NULL, NULL},
 	},
 	"1" },

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -362,9 +362,9 @@ struct retro_core_option_definition option_defs[] = {
 	},
 	"2" },
 
-	{INT_PCSX2_OPT_CLAMPING_MODE,
-	"Emulation: Clamping Mode",
-	"Clamping mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
+	{INT_PCSX2_OPT_EE_CLAMPING_MODE,
+	"Emulation: EE/FPU Clamping Mode",
+	"EE/FPU clamping mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
 	{
 		{"0", "None"},
 		{"1", "Normal (default)"},
@@ -375,9 +375,35 @@ struct retro_core_option_definition option_defs[] = {
 	"1" },
 
 
-	{INT_PCSX2_OPT_ROUND_MODE,
-	"Emulation: Round Mode",
-	"Round mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
+	{INT_PCSX2_OPT_EE_ROUND_MODE,
+	"Emulation: EE/FPU Round Mode",
+	"EE/FPU round mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
+	{
+		{"0", "Nearest"},
+		{"1", "Negative"},
+		{"2", "Positive"},
+		{"3", "Chop/Zero (default)"},
+		{NULL, NULL},
+	},
+	"3" },
+
+
+	{ INT_PCSX2_OPT_VU_CLAMPING_MODE,
+	"Emulation: VUs Clamping Mode",
+	"VUs clamping mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
+	{
+		{"0", "None"},
+		{"1", "Normal (default)"},
+		{"2", "Extra + Preserve Sign"},
+		{"3", "Full"},
+		{NULL, NULL},
+	},
+	"1" },
+
+
+	{ INT_PCSX2_OPT_VU_ROUND_MODE,
+	"Emulation: VUs Round Mode",
+	"VUs round mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
 	{
 		{"0", "Nearest"},
 		{"1", "Negative"},

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -374,18 +374,21 @@ void retro_init(void)
 		g_Conf->EmuOptions.EnableCheats = option_value(BOOL_PCSX2_OPT_ENABLE_CHEATS, KeyOptionBool::return_type);
 
 
-		int clampMode = option_value(INT_PCSX2_OPT_CLAMPING_MODE, KeyOptionInt::return_type);
-		g_Conf->EmuOptions.Cpu.Recompiler.fpuOverflow = (clampMode >= 1);
-		g_Conf->EmuOptions.Cpu.Recompiler.fpuExtraOverflow = (clampMode >= 2);
-		g_Conf->EmuOptions.Cpu.Recompiler.fpuFullMode = (clampMode >= 3);
+		int EE_clampMode = option_value(INT_PCSX2_OPT_EE_CLAMPING_MODE, KeyOptionInt::return_type);
+		g_Conf->EmuOptions.Cpu.Recompiler.fpuOverflow = (EE_clampMode >= 1);
+		g_Conf->EmuOptions.Cpu.Recompiler.fpuExtraOverflow = (EE_clampMode >= 2);
+		g_Conf->EmuOptions.Cpu.Recompiler.fpuFullMode = (EE_clampMode >= 3);
 
-		g_Conf->EmuOptions.Cpu.Recompiler.vuOverflow = (clampMode >= 1);
-		g_Conf->EmuOptions.Cpu.Recompiler.vuExtraOverflow = (clampMode >= 2);
-		g_Conf->EmuOptions.Cpu.Recompiler.vuSignOverflow = (clampMode >= 3);
+		SSE_RoundMode EE_roundMode = (SSE_RoundMode)option_value(INT_PCSX2_OPT_EE_ROUND_MODE, KeyOptionInt::return_type);
+		g_Conf->EmuOptions.Cpu.sseMXCSR.SetRoundMode(EE_roundMode);
 
-		SSE_RoundMode roundMode = (SSE_RoundMode)option_value(INT_PCSX2_OPT_ROUND_MODE, KeyOptionInt::return_type);;
-		g_Conf->EmuOptions.Cpu.sseMXCSR.SetRoundMode(roundMode);
-		g_Conf->EmuOptions.Cpu.sseVUMXCSR.SetRoundMode(roundMode);
+		int VUs_clampMode = option_value(INT_PCSX2_OPT_VU_CLAMPING_MODE, KeyOptionInt::return_type);
+		g_Conf->EmuOptions.Cpu.Recompiler.vuOverflow = (VUs_clampMode >= 1);
+		g_Conf->EmuOptions.Cpu.Recompiler.vuExtraOverflow = (VUs_clampMode >= 2);
+		g_Conf->EmuOptions.Cpu.Recompiler.vuSignOverflow = (VUs_clampMode >= 3);
+
+		SSE_RoundMode VUs_roundMode = (SSE_RoundMode)option_value(INT_PCSX2_OPT_VU_ROUND_MODE, KeyOptionInt::return_type);
+		g_Conf->EmuOptions.Cpu.sseVUMXCSR.SetRoundMode(VUs_roundMode);
 
 		static retro_disk_control_ext_callback disk_control = {
 			DiskControl::set_eject_state,

--- a/libretro/options_enums.h
+++ b/libretro/options_enums.h
@@ -40,8 +40,10 @@
 #define INT_PCSX2_OPT_TEXTURE_FILTERING		 "pcsx2_texture_filtering"
 #define INT_PCSX2_OPT_VSYNC_MTGS_QUEUE		 "pcsx2_vsync_mtgs_queue"
 #define INT_PCSX2_OPT_MIPMAPPING		 "pcsx2_mipmapping"
-#define INT_PCSX2_OPT_CLAMPING_MODE		 "pcsx2_clamping_mode"
-#define INT_PCSX2_OPT_ROUND_MODE		 "pcsx2_round_mode"
+#define INT_PCSX2_OPT_EE_CLAMPING_MODE		 "pcsx2_clamping_mode"
+#define INT_PCSX2_OPT_EE_ROUND_MODE		 "pcsx2_round_mode"
+#define INT_PCSX2_OPT_VU_CLAMPING_MODE		 "pcsx2_vu_clamping_mode"
+#define INT_PCSX2_OPT_VU_ROUND_MODE		 "pcsx2_vu_round_mode"
 #define INT_PCSX2_OPT_DITHERING		 "pcsx2_dithering"
 
 #define INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_X_HUNDREDS		"pcsx2_userhack_texture_offset_x_hundreds"


### PR DESCRIPTION
Made independent options for EE/FPU and VUs, as requested on issue #165   