### PR TITLE
Make the BIOS error message a bit more clear

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -277,7 +277,7 @@ void retro_init(void)
 	if (bios_files.size() == 0) {
 		std::string checked_path = bios_dir.GetFullPath().ToStdString();
 		log_cb(RETRO_LOG_ERROR, "Could not find valid BIOS files! \n");
-		log_cb(RETRO_LOG_ERROR, "Please provide required BIOS file in %s folder \n", checked_path.c_str());
+		log_cb(RETRO_LOG_ERROR, "Please provide required BIOS file in the following folder: '%s' \n", checked_path.c_str());
 		return;
 	}
 


### PR DESCRIPTION
A bit surprised by this, but it looks like some people literally named their BIOS folder "bios folder" after reading this error from the logs:

> [libretro ERROR] Please provide required BIOS file in /path/to/retroarch/system/pcsx2/bios folder

so I've changed it a bit, should avoid any confusion now:

> [libretro ERROR] Please provide required BIOS file in the following folder: '/path/to/retroarch/system/pcsx2/bios'