### PR TITLE
Fix small mistake with 32MB memory cards

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -170,7 +170,7 @@ void retro_init(void)
 	{
 		wxFileName found_file;
 		found_file.Assign(memcard_file);
-		if (!found_file.GetName().IsSameAs(FILENAME_SHARED_MEMCARD_8) && !found_file.GetName().IsSameAs(FILENAME_SHARED_MEMCARD_8))
+		if (!found_file.GetName().IsSameAs(FILENAME_SHARED_MEMCARD_8) && !found_file.GetName().IsSameAs(FILENAME_SHARED_MEMCARD_32))
 		{
 			if (found_file.GetExt().IsSameAs("ps2"))
 			{
@@ -194,7 +194,7 @@ void retro_init(void)
 	{
 		wxFileName found_file;
 		found_file.Assign(memcard_file);
-		if (!found_file.GetName().IsSameAs(FILENAME_SHARED_MEMCARD_8) && !found_file.GetName().IsSameAs(FILENAME_SHARED_MEMCARD_8))
+		if (!found_file.GetName().IsSameAs(FILENAME_SHARED_MEMCARD_8) && !found_file.GetName().IsSameAs(FILENAME_SHARED_MEMCARD_32))
 		{
 			if (found_file.GetExt().IsSameAs("ps2"))
 			{


### PR DESCRIPTION
Currently if a 32MB memory card has been created, it will appear twice in the core options:

![image](https://user-images.githubusercontent.com/33353403/135836032-65859b1e-f196-4207-b8a5-4d01bc7ad306.png)

This is harmless but might be confusing to some. The code was checking twice for 8MB card before creating the `[USER]` options, this really simple PR fixes that.