### PR TITLE
Add core options categories

### DIFF
--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -282,6 +282,7 @@ enum retro_language
    RETRO_LANGUAGE_PERSIAN             = 20,
    RETRO_LANGUAGE_HEBREW              = 21,
    RETRO_LANGUAGE_ASTURIAN            = 22,
+   RETRO_LANGUAGE_FINNISH             = 23,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -712,6 +713,9 @@ enum retro_mod
                                             * state of rumble motors in controllers.
                                             * A strong and weak motor is supported, and they can be
                                             * controlled indepedently.
+                                            * Should be called from either retro_init() or retro_load_game().
+                                            * Should not be called from retro_set_environment().
+                                            * Returns false if rumble functionality is unavailable.
                                             */
 #define RETRO_ENVIRONMENT_GET_INPUT_DEVICE_CAPABILITIES 24
                                            /* uint64_t * --
@@ -1127,6 +1131,13 @@ enum retro_mod
                                             * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
                                             * This allows the core to additionally set option sublabel information
                                             * and/or provide localisation support.
+                                            *
+                                            * If version is >= 2, core options may instead be set by passing
+                                            * a retro_core_options_v2 struct to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * or an array of retro_core_options_v2 structs to
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL. This allows the core
+                                            * to additionally set optional core option category information
+                                            * for frontends with core option category support.
                                             */
 
 #define RETRO_ENVIRONMENT_SET_CORE_OPTIONS 53
@@ -1168,7 +1179,7 @@ enum retro_mod
                                             * default value is NULL, the first entry in the
                                             * retro_core_option_definition::values array is treated as the default.
                                             *
-                                            * The number of possible options should be very limited,
+                                            * The number of possible option values should be very limited,
                                             * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
                                             * i.e. it should be feasible to cycle through options
                                             * without a keyboard.
@@ -1201,6 +1212,7 @@ enum retro_mod
                                             * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
                                             * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
                                             * Afterwards it may be called again for the core to communicate
@@ -1333,6 +1345,371 @@ enum retro_mod
                                             * If callback returns false, the number of active input
                                             * devices is unknown. In this case, all input devices
                                             * should be considered active.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK 62
+                                           /* const struct retro_audio_buffer_status_callback * --
+                                            * Lets the core know the occupancy level of the frontend
+                                            * audio buffer. Can be used by a core to attempt frame
+                                            * skipping in order to avoid buffer under-runs.
+                                            * A core may pass NULL to disable buffer status reporting
+                                            * in the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY 63
+                                           /* const unsigned * --
+                                            * Sets minimum frontend audio latency in milliseconds.
+                                            * Resultant audio latency may be larger than set value,
+                                            * or smaller if a hardware limit is encountered. A frontend
+                                            * is expected to honour requests up to 512 ms.
+                                            *
+                                            * - If value is less than current frontend
+                                            *   audio latency, callback has no effect
+                                            * - If value is zero, default frontend audio
+                                            *   latency is set
+                                            *
+                                            * May be used by a core to increase audio latency and
+                                            * therefore decrease the probability of buffer under-runs
+                                            * (crackling) when performing 'intensive' operations.
+                                            * A core utilising RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK
+                                            * to implement audio-buffer-based frame skipping may achieve
+                                            * optimal results by setting the audio latency to a 'high'
+                                            * (typically 6x or 8x) integer multiple of the expected
+                                            * frame time.
+                                            *
+                                            * WARNING: This can only be called from within retro_run().
+                                            * Calling this can require a full reinitialization of audio
+                                            * drivers in the frontend, so it is important to call it very
+                                            * sparingly, and usually only with the users explicit consent.
+                                            * An eventual driver reinitialize will happen so that audio
+                                            * callbacks happening after this call within the same retro_run()
+                                            * call will target the newly initialized driver.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
+                                           /* const struct retro_fastforwarding_override * --
+                                            * Used by a libretro core to override the current
+                                            * fastforwarding mode of the frontend.
+                                            * If NULL is passed to this function, the frontend
+                                            * will return true if fastforwarding override
+                                            * functionality is supported (no change in
+                                            * fastforwarding state will occur in this case).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE 65
+                                           /* const struct retro_system_content_info_override * --
+                                            * Allows an implementation to override 'global' content
+                                            * info parameters reported by retro_get_system_info().
+                                            * Overrides also affect subsystem content info parameters
+                                            * set via RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO.
+                                            * This function must be called inside retro_set_environment().
+                                            * If callback returns false, content info overrides
+                                            * are unsupported by the frontend, and will be ignored.
+                                            * If callback returns true, extended game info may be
+                                            * retrieved by calling RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+                                            * in retro_load_game() or retro_load_game_special().
+                                            *
+                                            * 'data' points to an array of retro_system_content_info_override
+                                            * structs terminated by a { NULL, false, false } element.
+                                            * If 'data' is NULL, no changes will be made to the frontend;
+                                            * a core may therefore pass NULL in order to test whether
+                                            * the RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE and
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT callbacks are supported
+                                            * by the frontend.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_system_content_info_override.
+                                            *
+                                            * Example:
+                                            *
+                                            * - struct retro_system_info:
+                                            * {
+                                            *    "My Core",                      // library_name
+                                            *    "v1.0",                         // library_version
+                                            *    "m3u|md|cue|iso|chd|sms|gg|sg", // valid_extensions
+                                            *    true,                           // need_fullpath
+                                            *    false                           // block_extract
+                                            * }
+                                            *
+                                            * - Array of struct retro_system_content_info_override:
+                                            * {
+                                            *    {
+                                            *       "md|sms|gg", // extensions
+                                            *       false,       // need_fullpath
+                                            *       true         // persistent_data
+                                            *    },
+                                            *    {
+                                            *       "sg",        // extensions
+                                            *       false,       // need_fullpath
+                                            *       false        // persistent_data
+                                            *    },
+                                            *    { NULL, false, false }
+                                            * }
+                                            *
+                                            * Result:
+                                            * - Files of type m3u, cue, iso, chd will not be
+                                            *   loaded by the frontend. Frontend will pass a
+                                            *   valid path to the core, and core will handle
+                                            *   loading internally
+                                            * - Files of type md, sms, gg will be loaded by
+                                            *   the frontend. A valid memory buffer will be
+                                            *   passed to the core. This memory buffer will
+                                            *   remain valid until retro_deinit() returns
+                                            * - Files of type sg will be loaded by the frontend.
+                                            *   A valid memory buffer will be passed to the core.
+                                            *   This memory buffer will remain valid until
+                                            *   retro_load_game() (or retro_load_game_special())
+                                            *   returns
+                                            *
+                                            * NOTE: If an extension is listed multiple times in
+                                            * an array of retro_system_content_info_override
+                                            * structs, only the first instance will be registered
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_GAME_INFO_EXT 66
+                                           /* const struct retro_game_info_ext ** --
+                                            * Allows an implementation to fetch extended game
+                                            * information, providing additional content path
+                                            * and memory buffer status details.
+                                            * This function may only be called inside
+                                            * retro_load_game() or retro_load_game_special().
+                                            * If callback returns false, extended game information
+                                            * is unsupported by the frontend. In this case, only
+                                            * regular retro_game_info will be available.
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT is guaranteed
+                                            * to return true if RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+                                            * returns true.
+                                            *
+                                            * 'data' points to an array of retro_game_info_ext structs.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_game_info_ext.
+                                            *
+                                            * - If function is called inside retro_load_game(),
+                                            *   the retro_game_info_ext array is guaranteed to
+                                            *   have a size of 1 - i.e. the returned pointer may
+                                            *   be used to access directly the members of the
+                                            *   first retro_game_info_ext struct, for example:
+                                            *
+                                            *      struct retro_game_info_ext *game_info_ext;
+                                            *      if (environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &game_info_ext))
+                                            *         printf("Content Directory: %s\n", game_info_ext->dir);
+                                            *
+                                            * - If the function is called inside retro_load_game_special(),
+                                            *   the retro_game_info_ext array is guaranteed to have a
+                                            *   size equal to the num_info argument passed to
+                                            *   retro_load_game_special()
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 67
+                                           /* const struct retro_core_options_v2 * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * 'data' points to a retro_core_options_v2 struct, containing
+                                            * of two pointers:
+                                            * - retro_core_options_v2::categories is an array of
+                                            *   retro_core_option_v2_category structs terminated by a
+                                            *   { NULL, NULL, NULL } element. If retro_core_options_v2::categories
+                                            *   is NULL, all core options will have no category and will be shown
+                                            *   at the top level of the frontend core option interface. If frontend
+                                            *   does not have core option category support, categories array will
+                                            *   be ignored.
+                                            * - retro_core_options_v2::definitions is an array of
+                                            *   retro_core_option_v2_definition structs terminated by a
+                                            *   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL }
+                                            *   element.
+                                            *
+                                            * >> retro_core_option_v2_category notes:
+                                            *
+                                            * - retro_core_option_v2_category::key should contain string
+                                            *   that uniquely identifies the core option category. Valid
+                                            *   key characters are [a-z, A-Z, 0-9, _, -]
+                                            *   Namespace collisions with other implementations' category
+                                            *   keys are permitted.
+                                            * - retro_core_option_v2_category::desc should contain a human
+                                            *   readable description of the category key.
+                                            * - retro_core_option_v2_category::info should contain any
+                                            *   additional human readable information text that a typical
+                                            *   user may need to understand the nature of the core option
+                                            *   category.
+                                            *
+                                            * Example entry:
+                                            * {
+                                            *     "advanced_settings",
+                                            *     "Advanced",
+                                            *     "Options affecting low-level emulation performance and accuracy."
+                                            * }
+                                            *
+                                            * >> retro_core_option_v2_definition notes:
+                                            *
+                                            * - retro_core_option_v2_definition::key should be namespaced to not
+                                            *   collide with other implementations' keys. e.g. A core called
+                                            *   'foo' should use keys named as 'foo_option'. Valid key characters
+                                            *   are [a-z, A-Z, 0-9, _, -].
+                                            * - retro_core_option_v2_definition::desc should contain a human readable
+                                            *   description of the key. Will be used when the frontend does not
+                                            *   have core option category support. Examples: "Aspect Ratio" or
+                                            *   "Video > Aspect Ratio".
+                                            * - retro_core_option_v2_definition::desc_categorized should contain a
+                                            *   human readable description of the key, which will be used when
+                                            *   frontend has core option category support. Example: "Aspect Ratio",
+                                            *   where associated retro_core_option_v2_category::desc is "Video".
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::desc will be used instead.
+                                            *   retro_core_option_v2_definition::desc_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::info should contain any additional
+                                            *   human readable information text that a typical user may need to
+                                            *   understand the functionality of the option.
+                                            * - retro_core_option_v2_definition::info_categorized should contain
+                                            *   any additional human readable information text that a typical user
+                                            *   may need to understand the functionality of the option, and will be
+                                            *   used when frontend has core option category support. This is provided
+                                            *   to accommodate the case where info text references an option by
+                                            *   name/desc, and the desc/desc_categorized text for that option differ.
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::info will be used instead.
+                                            *   retro_core_option_v2_definition::info_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::category_key should contain a
+                                            *   category identifier (e.g. "video" or "audio") that will be
+                                            *   assigned to the core option if frontend has core option category
+                                            *   support. A categorized option will be shown in a subsection/
+                                            *   submenu of the frontend core option interface. If key is empty
+                                            *   or NULL, or if key does not match one of the
+                                            *   retro_core_option_v2_category::key values in the associated
+                                            *   retro_core_option_v2_category array, option will have no category
+                                            *   and will be shown at the top level of the frontend core option
+                                            *   interface.
+                                            * - retro_core_option_v2_definition::values is an array of
+                                            *   retro_core_option_value structs terminated by a { NULL, NULL }
+                                            *   element.
+                                            * --> retro_core_option_v2_definition::values[index].value is an
+                                            *     expected option value.
+                                            * --> retro_core_option_v2_definition::values[index].label is a
+                                            *     human readable label used when displaying the value on screen.
+                                            *     If NULL, the value itself is used.
+                                            * - retro_core_option_v2_definition::default_value is the default
+                                            *   core option setting. It must match one of the expected option
+                                            *   values in the retro_core_option_v2_definition::values array. If
+                                            *   it does not, or the default value is NULL, the first entry in the
+                                            *   retro_core_option_v2_definition::values array is treated as the
+                                            *   default.
+                                            *
+                                            * The number of possible option values should be very limited,
+                                            * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
+                                            * i.e. it should be feasible to cycle through options
+                                            * without a keyboard.
+                                            *
+                                            * Example entries:
+                                            *
+                                            * - Uncategorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Speed hack coprocessor X",
+                                            *     NULL,
+                                            *     "Provides increased performance at the expense of reduced accuracy.",
+                                            *     NULL,
+                                            *     NULL,
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * - Categorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Advanced > Speed hack coprocessor X",
+                                            *     "Speed hack coprocessor X",
+                                            *     "Setting 'Advanced > Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "Setting 'Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "advanced_settings",
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * Only strings are operated on. The possible values will
+                                            * generally be displayed and stored as-is by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL 68
+                                           /* const struct retro_core_options_v2_intl * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * This is fundamentally the same as RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * with the addition of localisation support. The description of the
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 callback should be consulted
+                                            * for further details.
+                                            *
+                                            * 'data' points to a retro_core_options_v2_intl struct.
+                                            *
+                                            * - retro_core_options_v2_intl::us is a pointer to a
+                                            *   retro_core_options_v2 struct defining the US English
+                                            *   core options implementation. It must point to a valid struct.
+                                            *
+                                            * - retro_core_options_v2_intl::local is a pointer to a
+                                            *   retro_core_options_v2 struct defining core options for
+                                            *   the current frontend language. It may be NULL (in which case
+                                            *   retro_core_options_v2_intl::us is used by the frontend). Any items
+                                            *   missing from this struct will be read from
+                                            *   retro_core_options_v2_intl::us instead.
+                                            *
+                                            * NOTE: Default core option values are always taken from the
+                                            * retro_core_options_v2_intl::us struct. Any default values in
+                                            * the retro_core_options_v2_intl::local struct will be ignored.
                                             */
 
 /* VFS functionality */
@@ -2224,6 +2601,30 @@ struct retro_frame_time_callback
    retro_usec_t reference;
 };
 
+/* Notifies a libretro core of the current occupancy
+ * level of the frontend audio buffer.
+ *
+ * - active: 'true' if audio buffer is currently
+ *           in use. Will be 'false' if audio is
+ *           disabled in the frontend
+ *
+ * - occupancy: Given as a value in the range [0,100],
+ *              corresponding to the occupancy percentage
+ *              of the audio buffer
+ *
+ * - underrun_likely: 'true' if the frontend expects an
+ *                    audio buffer underrun during the
+ *                    next frame (indicates that a core
+ *                    should attempt frame skipping)
+ *
+ * It will be called right before retro_run() every frame. */
+typedef void (RETRO_CALLCONV *retro_audio_buffer_status_callback_t)(
+      bool active, unsigned occupancy, bool underrun_likely);
+struct retro_audio_buffer_status_callback
+{
+   retro_audio_buffer_status_callback_t callback;
+};
+
 /* Pass this to retro_video_refresh_t if rendering to hardware.
  * Passing NULL to retro_video_refresh_t is still a frame dupe as normal.
  * */
@@ -2672,7 +3073,7 @@ struct retro_input_descriptor
 struct retro_system_info
 {
    /* All pointers are owned by libretro implementation, and pointers must
-    * remain valid until retro_deinit() is called. */
+    * remain valid until it is unloaded. */
 
    const char *library_name;      /* Descriptive name of library. Should not
                                    * contain any version numbers, etc. */
@@ -2712,6 +3113,213 @@ struct retro_system_info
     * Necessary for certain libretro implementations that load games
     * from zipped archives. */
    bool        block_extract;
+};
+
+/* Defines overrides which modify frontend handling of
+ * specific content file types.
+ * An array of retro_system_content_info_override is
+ * passed to RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_system_content_info_override
+{
+   /* A list of file extensions for which the override
+    * should apply, delimited by a 'pipe' character
+    * (e.g. "md|sms|gg")
+    * Permitted file extensions are limited to those
+    * included in retro_system_info::valid_extensions
+    * and/or retro_subsystem_rom_info::valid_extensions */
+   const char *extensions;
+
+   /* Overrides the need_fullpath value set in
+    * retro_system_info and/or retro_subsystem_rom_info.
+    * To reiterate:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info::path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info::data and retro_game_info::size are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - retro_game_info::path may be NULL
+    *    - retro_game_info::data and retro_game_info::size are guaranteed
+    *      to be valid
+    *
+    * In addition:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info_ext::full_path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info_ext::archive_path may be NULL
+    *    - retro_game_info_ext::archive_file may be NULL
+    *    - retro_game_info_ext::dir is guaranteed to contain a valid path
+    *      to the directory in which the content file exists
+    *    - retro_game_info_ext::name is guaranteed to contain the
+    *      basename of the content file, without extension
+    *    - retro_game_info_ext::ext is guaranteed to contain the
+    *      extension of the content file in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - If retro_game_info_ext::file_in_archive is false:
+    *       - retro_game_info_ext::full_path is guaranteed to contain
+    *         a valid path to an existent file
+    *       - retro_game_info_ext::archive_path may be NULL
+    *       - retro_game_info_ext::archive_file may be NULL
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the content file exists
+    *       - retro_game_info_ext::name is guaranteed to contain the
+    *         basename of the content file, without extension
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file in lower case format
+    *    - If retro_game_info_ext::file_in_archive is true:
+    *       - retro_game_info_ext::full_path may be NULL
+    *       - retro_game_info_ext::archive_path is guaranteed to
+    *         contain a valid path to an existent compressed file
+    *         inside which the content file is located
+    *       - retro_game_info_ext::archive_file is guaranteed to
+    *         contain a valid path to an existent content file
+    *         inside the compressed file referred to by
+    *         retro_game_info_ext::archive_path
+    *            e.g. for a compressed file '/path/to/foo.zip'
+    *            containing 'bar.sfc'
+    *             > retro_game_info_ext::archive_path will be '/path/to/foo.zip'
+    *             > retro_game_info_ext::archive_file will be 'bar.sfc'
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the compressed file
+    *         (containing the content file) exists
+    *       - retro_game_info_ext::name is guaranteed to contain
+    *         EITHER
+    *         1) the basename of the compressed file (containing
+    *            the content file), without extension
+    *         OR
+    *         2) the basename of the content file inside the
+    *            compressed file, without extension
+    *         In either case, a core should consider 'name' to
+    *         be the canonical name/ID of the the content file
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file inside the compressed file,
+    *         in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size are
+    *      guaranteed to be valid */
+   bool need_fullpath;
+
+   /* If need_fullpath is false, specifies whether the content
+    * data buffer available in retro_load_game() is 'persistent'
+    *
+    * If persistent_data is false and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid only until retro_load_game() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid only until retro_load_game() returns
+    *
+    * If persistent_data is true and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid until retro_deinit() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid until retro_deinit() returns */
+   bool persistent_data;
+};
+
+/* Similar to retro_game_info, but provides extended
+ * information about the source content file and
+ * game memory buffer status.
+ * And array of retro_game_info_ext is returned by
+ * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_game_info_ext
+{
+   /* - If file_in_archive is false, contains a valid
+    *   path to an existent content file (UTF-8 encoded)
+    * - If file_in_archive is true, may be NULL */
+   const char *full_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contains a valid path
+    *   to an existent compressed file inside which the
+    *   content file is located (UTF-8 encoded) */
+   const char *archive_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contain a valid path
+    *   to an existent content file inside the compressed
+    *   file referred to by archive_path (UTF-8 encoded)
+    *      e.g. for a compressed file '/path/to/foo.zip'
+    *      containing 'bar.sfc'
+    *      > archive_path will be '/path/to/foo.zip'
+    *      > archive_file will be 'bar.sfc' */
+   const char *archive_file;
+
+   /* - If file_in_archive is false, contains a valid path
+    *   to the directory in which the content file exists
+    *   (UTF-8 encoded)
+    * - If file_in_archive is true, contains a valid path
+    *   to the directory in which the compressed file
+    *   (containing the content file) exists (UTF-8 encoded) */
+   const char *dir;
+
+   /* Contains the canonical name/ID of the content file
+    * (UTF-8 encoded). Intended for use when identifying
+    * 'complementary' content named after the loaded file -
+    * i.e. companion data of a different format (a CD image
+    * required by a ROM), texture packs, internally handled
+    * save files, etc.
+    * - If file_in_archive is false, contains the basename
+    *   of the content file, without extension
+    * - If file_in_archive is true, then string is
+    *   implementation specific. A frontend may choose to
+    *   set a name value of:
+    *   EITHER
+    *   1) the basename of the compressed file (containing
+    *      the content file), without extension
+    *   OR
+    *   2) the basename of the content file inside the
+    *      compressed file, without extension
+    *   RetroArch sets the 'name' value according to (1).
+    *   A frontend that supports routine loading of
+    *   content from archives containing multiple unrelated
+    *   content files may set the 'name' value according
+    *   to (2). */
+   const char *name;
+
+   /* - If file_in_archive is false, contains the extension
+    *   of the content file in lower case format
+    * - If file_in_archive is true, contains the extension
+    *   of the content file inside the compressed file,
+    *   in lower case format */
+   const char *ext;
+
+   /* String of implementation specific meta-data. */
+   const char *meta;
+
+   /* Memory buffer of loaded game content. Will be NULL:
+    * IF
+    * - retro_system_info::need_fullpath is true and
+    *   retro_system_content_info_override::need_fullpath
+    *   is unset
+    * OR
+    * - retro_system_content_info_override::need_fullpath
+    *   is true */
+   const void *data;
+
+   /* Size of game content memory buffer, in bytes */
+   size_t size;
+
+   /* True if loaded content file is inside a compressed
+    * archive */
+   bool file_in_archive;
+
+   /* - If data is NULL, value is unset/ignored
+    * - If data is non-NULL:
+    *   - If persistent_data is false, data and size are
+    *     valid only until retro_load_game() returns
+    *   - If persistent_data is true, data and size are
+    *     are valid until retro_deinit() returns */
+   bool persistent_data;
 };
 
 struct retro_game_geometry
@@ -2825,6 +3433,124 @@ struct retro_core_options_intl
    struct retro_core_option_definition *local;
 };
 
+struct retro_core_option_v2_category
+{
+   /* Variable uniquely identifying the
+    * option category. Valid key characters
+    * are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable category description
+    * > Used as category menu label when
+    *   frontend has core option category
+    *   support */
+   const char *desc;
+
+   /* Human-readable category information
+    * > Used as category menu sublabel when
+    *   frontend has core option category
+    *   support
+    * > Optional (may be NULL or an empty
+    *   string) */
+   const char *info;
+};
+
+struct retro_core_option_v2_definition
+{
+   /* Variable to query in RETRO_ENVIRONMENT_GET_VARIABLE.
+    * Valid key characters are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend does
+    *   not have core option category support
+    *   e.g. "Video > Aspect Ratio" */
+   const char *desc;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend has
+    *   core option category support
+    *   e.g. "Aspect Ratio", where associated
+    *   retro_core_option_v2_category::desc
+    *   is "Video"
+    * > If empty or NULL, the string specified by
+    *   desc will be used as the menu label
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *desc_categorized;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel */
+   const char *info;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel when frontend
+    *   has core option category support
+    *   (e.g. may be required when info text
+    *   references an option by name/desc,
+    *   and the desc/desc_categorized text
+    *   for that option differ)
+    * > If empty or NULL, the string specified by
+    *   info will be used as the menu sublabel
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *info_categorized;
+
+   /* Variable specifying category (e.g. "video",
+    * "audio") that will be assigned to the option
+    * if frontend has core option category support.
+    * > Categorized options will be displayed in a
+    *   subsection/submenu of the frontend core
+    *   option interface
+    * > Specified string must match one of the
+    *   retro_core_option_v2_category::key values
+    *   in the associated retro_core_option_v2_category
+    *   array; If no match is not found, specified
+    *   string will be considered as NULL
+    * > If specified string is empty or NULL, option will
+    *   have no category and will be shown at the top
+    *   level of the frontend core option interface */
+   const char *category_key;
+
+   /* Array of retro_core_option_value structs, terminated by NULL */
+   struct retro_core_option_value values[RETRO_NUM_CORE_OPTION_VALUES_MAX];
+
+   /* Default core option value. Must match one of the values
+    * in the retro_core_option_value array, otherwise will be
+    * ignored */
+   const char *default_value;
+};
+
+struct retro_core_options_v2
+{
+   /* Array of retro_core_option_v2_category structs,
+    * terminated by NULL
+    * > If NULL, all entries in definitions array
+    *   will have no category and will be shown at
+    *   the top level of the frontend core option
+    *   interface
+    * > Will be ignored if frontend does not have
+    *   core option category support */
+   struct retro_core_option_v2_category *categories;
+
+   /* Array of retro_core_option_v2_definition structs,
+    * terminated by NULL */
+   struct retro_core_option_v2_definition *definitions;
+};
+
+struct retro_core_options_v2_intl
+{
+   /* Pointer to a retro_core_options_v2 struct
+    * > US English implementation
+    * > Must point to a valid struct */
+   struct retro_core_options_v2 *us;
+
+   /* Pointer to a retro_core_options_v2 struct
+    * - Implementation for current frontend language
+    * - May be NULL */
+   struct retro_core_options_v2 *local;
+};
+
 struct retro_game_info
 {
    const char *path;       /* Path to game, UTF-8 encoded.
@@ -2869,6 +3595,47 @@ struct retro_framebuffer
    unsigned memory_flags;           /* Flags telling core how the memory has been mapped.
                                        RETRO_MEMORY_TYPE_* flags.
                                        Set by frontend in GET_CURRENT_SOFTWARE_FRAMEBUFFER. */
+};
+
+/* Used by a libretro core to override the current
+ * fastforwarding mode of the frontend */
+struct retro_fastforwarding_override
+{
+   /* Specifies the runtime speed multiplier that
+    * will be applied when 'fastforward' is true.
+    * For example, a value of 5.0 when running 60 FPS
+    * content will cap the fast-forward rate at 300 FPS.
+    * Note that the target multiplier may not be achieved
+    * if the host hardware has insufficient processing
+    * power.
+    * Setting a value of 0.0 (or greater than 0.0 but
+    * less than 1.0) will result in an uncapped
+    * fast-forward rate (limited only by hardware
+    * capacity).
+    * If the value is negative, it will be ignored
+    * (i.e. the frontend will use a runtime speed
+    * multiplier of its own choosing) */
+   float ratio;
+
+   /* If true, fastforwarding mode will be enabled.
+    * If false, fastforwarding mode will be disabled. */
+   bool fastforward;
+
+   /* If true, and if supported by the frontend, an
+    * on-screen notification will be displayed while
+    * 'fastforward' is true.
+    * If false, and if supported by the frontend, any
+    * on-screen fast-forward notifications will be
+    * suppressed */
+   bool notification;
+
+   /* If true, the core will have sole control over
+    * when fastforwarding mode is enabled/disabled;
+    * the frontend will not be able to change the
+    * state set by 'fastforward' until either
+    * 'inhibit_toggle' is set to false, or the core
+    * is unloaded */
+   bool inhibit_toggle;
 };
 
 /* Callbacks */

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1,756 +1,1061 @@
 #ifndef LIBRETRO_CORE_OPTIONS_H__
 #define LIBRETRO_CORE_OPTIONS_H__
+
 #include <stdlib.h>
 #include <string.h>
+
 #include <libretro.h>
 #include <retro_inline.h>
+
 #include "options_enums.h"
+
+#ifndef HAVE_NO_LANGEXTRA
+#include "libretro_core_options_intl.h"
 #endif
 
-struct retro_core_option_definition option_defs[] = {
+/*
+ ********************************
+ * VERSION: 2.0
+ ********************************
+ *
+ * - 2.0: Add support for core options v2 interface
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
 
-	{STRING_PCSX2_OPT_BIOS,
-	"System: BIOS",
-	NULL,
-	{
-		// dynamically filled in retro_init
-	},
-	NULL},
-
-	{STRING_PCSX2_OPT_SYSTEM_LANGUAGE,
-	"System: Language",
-	"Set the BIOS system Language. Useful for PAL multilanguage games. Fastboot option must be disabled. The selected language will be applied, if available in-game. (Content restart required)",
-	{
-		{"English", NULL},
-		{"French", NULL},
-		{"Spanish", NULL},
-		{"German", NULL},
-		{"Italian", NULL},
-		{"Dutch", NULL},
-		{"Portuguese", NULL},
-		{NULL, NULL},
-	},
-	"English"},
-
-	{BOOL_PCSX2_OPT_FASTCDVD,
-	"System: Fast Loading",
-	"A hack that reduces loading times by setting a faster disc access mode. Check the HDLoader compatibility list for games that will not work with this (Content restart required)",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled"},
-
-	{BOOL_PCSX2_OPT_FASTBOOT,
-	"System: Fast Boot",
-	"Bypass the initial BIOS logo. (Content restart required)",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled"},
-
-	{BOOL_PCSX2_OPT_BOOT_TO_BIOS,
-	"System: Boot To BIOS",
-	"Skip the content loading and boot in the BIOS. Useful to manage memory cards currently associated to this content. (Content restart required)",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled"},
-
-	{STRING_PCSX2_OPT_MEMCARD_SLOT_1,
-	"Memory Card: Slot 1",
-	"Select the primary memory card to use. 'Legacy' points to the memory card Mcd001 in the old location system/pcsx2/memcards. (Content restart required)",
-	{
-		// dynamically filled in retro_init
-	},
-	NULL},
-
-	{STRING_PCSX2_OPT_MEMCARD_SLOT_2,
-	"Memory Card: Slot 2",
-	"Select the secondary memory card to use. 'Legacy' points to the memory card Mcd002 in the old location system/pcsx2/memcards. (Content restart required)",
-	{
-		// dynamically filled in retro_init
-	},
-	NULL },
-
-
-	{STRING_PCSX2_OPT_RENDERER,
-	"Video: Renderer",
-	"Content reboot required",
-	{
-		{"Auto", NULL},
-#ifdef _WIN32
-		{"D3D11", NULL},
+#ifdef __cplusplus
+extern "C" {
 #endif
-		{"OpenGl", NULL},
-		{NULL, NULL},
-	},
-	"Auto"},
 
-	{INT_PCSX2_OPT_UPSCALE_MULTIPLIER,
-	"Video: Internal Resolution ",
-	NULL,
-	{
-		{"1", "Native PS2"},
-		{"2", "2x Native ~720p"},
-		{"3", "3x Native ~1080p"},
-		{"4", "4x Native ~1440p 2K"},
-		{"5", "5x Native ~1620p 3K"},
-		{"6", "6x Native ~2160p 4K"},
-		{"8", "8x Native ~2880p 5K"},
-		{NULL, NULL},
-	},
-	"1"},
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
 
-	{INT_PCSX2_OPT_DEINTERLACING_MODE,
-	"Video: Deinterlacing Mode",
-	"Can remove blur on some games. Some modes can slightly decrease performance while others can blur the whole picture, decreasing the amount of details thus deinterlacing is to be used only when it's necessary. NOTE: Setting this to 'No interlacing patch' will try to apply a no-interlacing patch if available in the database. No-interlacing has the best image quality, but might not always be available for your game. NOTE: No-interlacing option requires a content restart.",
-	{
-		{"7", "Automatic (default)"},
-		{"6", "Blend bff - slight blur, 1/2 fps"},
-		{"5", "Blend tff - slight blur, 1/2 fps"},
-		{"4", "Bob bff   - use blend if shaking"},
-		{"3", "Bob tff   - use blend if shaking"},
-		{"2", "Weave bff - saw-tooth"},
-		{"1", "Weave tff - saw-tooth"},
-		{"0", "None "},
-		{"-1","No-interlacing patch"},
-		{NULL, NULL},
-	},
-	"7"},
+/* RETRO_LANGUAGE_ENGLISH */
 
-	{INT_PCSX2_OPT_ASPECT_RATIO,
-	"Video: Aspect Ratio",
-	"Sets the aspect ratio. Setting the aspect ratio to Widescreen (16:9) stretches the display. For proper widescreen in select games, also turn on the 'Enable Widescreen Patches' option. (Content restart required)",
-	{
-		{"0", "Standard (4:3)"},
-		{"1", "Widescreen (16:9)"},
-		{NULL, NULL},
-	},
-	"0"},
+/* Default language:
+ * - All other languages must include the same keys and values
+ * - Will be used as a fallback in the event that frontend language
+ *   is not available
+ * - Will be used as a fallback for any missing entries in
+ *   frontend language definition */
 
-	{BOOL_PCSX2_OPT_ENABLE_WIDESCREEN_PATCHES,
-	"Video: Enable Widescreen Patches",
-	"Enables widescreen patches that allow certain games to render in true 16:9 ratio without stretching the display. For the widescreen patches to display properly, the 'Aspect Ratio' option should be set to Widescreen (16:9). (Content restart required)",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled"},
-
-	{BOOL_PCSX2_OPT_ENABLE_60FPS_PATCHES,
-	"Video: Enable 60fps Patches",
-	"Enables 60fps patches that allow certain games to run at higher framerates than the original framerate. NOTE: No guarantees about stability or game bugs, use at your own caution. (Content restart required)",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled"},
-
-	{INT_PCSX2_OPT_FXAA,
-	"Video: FXAA",
-	"Enables Fast Approximate Anti-Aliasing",
-	{
-		{"0", "Disabled"},
-		{"1", "Enabled"},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{INT_PCSX2_OPT_ANISOTROPIC_FILTER,
-	 "Video: Anisotropic Filtering",
-	 "Reduces texture aliasing at extreme viewing angles",
-	{
-		{"0", "None"},
-		{"2", "2x"},
-		{"4", "4x"},
-		{"8", "8x"},
-		{"16", "16x"},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{ INT_PCSX2_OPT_DITHERING,
-	 "Video: Dithering",
-	 "Disabling dithering can remove some noise and pixelate effects",
-	{
-		{"0", "Off"},
-		{"1", "Scaled"},
-		{"2", "Unscaled (default)"},
-		{NULL, NULL},
-	},
-	"2" },
-
-	{INT_PCSX2_OPT_TEXTURE_FILTERING,
-	"Video: Texture Filtering",
-	"Controls the texture filtering of the emulation "
-		"\nNearest: always disable interpolation, rendering will be blocky. "
-		"\nBilinear Forced: always enable interpolation. Rendering is smoother but it could generate some glitches. "
-		"\nBilinear PS2: use same mode as the PS2. It is the more accurate option."
-		"\nBilinear Forced (excluding sprite): always enable interpolation except for sprites (FMV/Text/2D elements). Rendering is smoother but it could generate a few glitches. If upscaling is enabled, this setting is recommended over 'Bilinear Forced ",
-	{
-		{"0", "Nearest"},
-		{"1", "Bilinear (Forced)"},
-		{"2", "Bilinear (PS2 - Default)"},
-		{"3", "Bilinear (Forced Excluding Sprite)"},
-		{NULL, NULL},
-	},
-	"2" },
-
-	{INT_PCSX2_OPT_MIPMAPPING,
-	 "Video: Mipmapping",
-	 "Control the accuracy level of the mipmapping emulation."
-		"\nAutomatic: Automatically sets the mipmapping level based on the game.This is the recommended setting."
-		"\nOff: Mipmapping emulation is disabled."
-		"\nBasic (Fast): Partially emulates mipmapping, performance impact is negligible in most cases."
-		"\nFull (Slow):  Completely emulates the mipmapping function of the GS, might significantly impact performance.",
-	{
-		{"-1", "Automatic (default)"},
-		{"0", "Off"},
-		{"1", "Basic"},
-		{"2", "Full"},
-
-		{NULL, NULL},
-	},
-	"-1" },
-
-	{BOOL_PCSX2_OPT_CONSERVATIVE_BUFFER,
-	"Video: Conservative Buffer Allocation",
-	"Disabled: Reserves a larger framebuffer to prevent FMV flickers. Increases GPU/memory requirements."
-		"\n\nDisabling this can amplify stuttering due to low RAM/VRAM."
-		"\nNote: It should be enabled for Armored Core, Destroy All Humans, Gran Turismo and possibly others."
-		"\nThis option does not improve the graphics or the FPS.",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"enabled" },
-
-	{BOOL_PCSX2_OPT_ACCURATE_DATE,
-	"Video: Accurate DATE",
-	"Implement a more accurate algorithm to compute GS destination alpha testing. It improves shadow and transparency rendering."
-				"\nNote: Direct3D 11 is less accurate.",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"enabled" },
-
-
-	{BOOL_PCSX2_OPT_FRAMESKIP,
-	"Video: Frame Skip",
-	NULL,
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled" },
-
-	{INT_PCSX2_OPT_FRAMES_TO_DRAW,
-	"Video: Frameskip - Frames to Draw",
-	NULL,
-	{
-		{"1", NULL},
-		{"2", NULL},
-		{"3", NULL},
-		{"4", NULL},
-		{"5", NULL},
-		{"6", NULL},
-		{"7", NULL},
-		{"8", NULL},
-		{"9", NULL},
-		{"10", NULL},
-		{NULL, NULL},
-	},
-	"1" },
-
-	{INT_PCSX2_OPT_FRAMES_TO_SKIP,
-	"Video: Frameskip - Frames to Skip",
-	NULL,
-	{
-		{"1", NULL},
-		{"2", NULL},
-		{"3", NULL},
-		{"4", NULL},
-		{"5", NULL},
-		{"6", NULL},
-		{"7", NULL},
-		{"8", NULL},
-		{"9", NULL},
-		{"10", NULL},
-		{NULL, NULL},
-	},
-	"1" },
-
-	{BOOL_PCSX2_OPT_GAMEPAD_RUMBLE_ENABLE,
-	"Gamepad: Enable Rumble",
-	"Enables rumble on gamepads that support it",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"enabled"},
-
-	{INT_PCSX2_OPT_GAMEPAD_RUMBLE_FORCE,
-	"Gamepad: Rumble Intensity",
-	"Intensity of gamepad rumble",
-	{
-		{"10", "10%"},
-		{"20", "20%"},
-		{"30", "30%"},
-		{"40", "40%"},
-		{"50", "50%"},
-		{"60", "60%"},
-		{"70", "70%"},
-		{"80", "80%"},
-		{"90", "90%"},
-		{"100", "100%"},
-		{NULL, NULL},
-	},
-	"100"},
-
-	{ INT_PCSX2_OPT_GAMEPAD_L_DEADZONE,
-	"Gamepad: Left Stick Dead Zone",
-	"Set the dead zone of left thumbstick",
-	{
-		{"0", "No Dead Zone (default)"},
-		{"1", "1%"},
-		{"2", "2%"},
-		{"3", "3%"},
-		{"4", "4%"},
-		{"5", "5%"},
-		{"6", "6%"},
-		{"7", "7%"},
-		{"8", "8%"},
-		{"9", "9%"},
-		{"10", "10%"},
-		{"11", "11%"},
-		{"12", "12%"},
-		{"13", "13%"},
-		{"14", "14%"},
-		{"15", "15%"},
-		{"16", "16%"},
-		{"17", "17%"},
-		{"18", "18%"},
-		{"19", "19%"},
-		{"20", "20%"},
-		{"21", "21%"},
-		{"22", "22%"},
-		{"23", "23%"},
-		{"24", "24%"},
-		{"25", "25%"},
-		{"26", "26%"},
-		{"27", "27%"},
-		{"28", "28%"},
-		{"29", "29%"},
-		{"30", "30%"},
-		{"31", "31%"},
-		{"32", "32%"},
-		{"33", "33%"},
-		{"34", "34%"},
-		{"35", "35%"},
-		{"36", "36%"},
-		{"37", "37%"},
-		{"38", "38%"},
-		{"39", "39%"},
-		{"40", "40%"},
-		{"41", "41%"},
-		{"42", "42%"},
-		{"43", "43%"},
-		{"44", "44%"},
-		{"45", "45%"},
-		{"46", "46%"},
-		{"47", "47%"},
-		{"48", "48%"},
-		{"49", "49%"},
-		{"50", "50%"},
-		{NULL, NULL},
-	},
-	"enabled" },
-
-
-	{ INT_PCSX2_OPT_GAMEPAD_R_DEADZONE,
-	"Gamepad: Right Stick Dead Zone",
-	"Set the dead zone of right thumbstick",
-	{
-		{"0", "No Dead Zone (default)"},
-		{"1", "1%"},
-		{"2", "2%"},
-		{"3", "3%"},
-		{"4", "4%"},
-		{"5", "5%"},
-		{"6", "6%"},
-		{"7", "7%"},
-		{"8", "8%"},
-		{"9", "9%"},
-		{"10", "10%"},
-		{"11", "11%"},
-		{"12", "12%"},
-		{"13", "13%"},
-		{"14", "14%"},
-		{"15", "15%"},
-		{"16", "16%"},
-		{"17", "17%"},
-		{"18", "18%"},
-		{"19", "19%"},
-		{"20", "20%"},
-		{"21", "21%"},
-		{"22", "22%"},
-		{"23", "23%"},
-		{"24", "24%"},
-		{"25", "25%"},
-		{"26", "26%"},
-		{"27", "27%"},
-		{"28", "28%"},
-		{"29", "29%"},
-		{"30", "30%"},
-		{"31", "31%"},
-		{"32", "32%"},
-		{"33", "33%"},
-		{"34", "34%"},
-		{"35", "35%"},
-		{"36", "36%"},
-		{"37", "37%"},
-		{"38", "38%"},
-		{"39", "39%"},
-		{"40", "40%"},
-		{"41", "41%"},
-		{"42", "42%"},
-		{"43", "43%"},
-		{"44", "44%"},
-		{"45", "45%"},
-		{"46", "46%"},
-		{"47", "47%"},
-		{"48", "48%"},
-		{"49", "49%"},
-		{"50", "50%"},
-		{NULL, NULL},
-	},
-	"enabled" },
-
-	{BOOL_PCSX2_OPT_ENABLE_CHEATS,
-	"Patches: Enable Cheats",
-	"Enabled: Checks the 'system/pcsx2/cheats' directory for a PNACH file for the running content and, if found, \
-	applies the cheats from the file. (Content restart required)",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled" },
-
-	{INT_PCSX2_OPT_SPEEDHACKS_PRESET,
-	 "Emulation: Speed Hacks Preset",
-	 "Preset which controls the balance between accuracy and speed. (Content restart required) \
-		\nSafest: no speed hacks. Most reliable, but possibly slow. \
-		\nSafe: a few speed hacks known to provide boosts with minimal to no side effects. \
-		\nBalanced: recommended preset for CPUs with 4+ cores. Provides good boosts with minimal to no side effects. \
-		\nAggressive/Very Aggressive: may help underpowered CPUs in less demanding games, but may cause problems in other cases. \
-		\nMostly Harmful: helps a very small set of games with unusual performance requirements. Not recommended for underpowered devices.",
-	{
-		{"0", "Safest - No Hacks"},
-		{"1", "Safe (default)"},
-		{"2", "Balanced"},
-		{"3", "Aggressive"},
-		{"4", "Very Aggressive"},
-		{"5", "Mostly Harmful"},
-		{NULL, NULL},
-	},
-	"1" },
-
-	{INT_PCSX2_OPT_VSYNC_MTGS_QUEUE,
-	"Emulation: Vsyncs in MTGS Queue",
-	"Setting this to a lower value improves input lag, a value around 2 or 3 will slightly improve framerates.",
-	{
-		{"0", "0"},
-		{"1", "1"},
-		{"2", "2 (default)"},
-		{"3", "3"},
-		{NULL, NULL},
-	},
-	"2" },
-
-	{INT_PCSX2_OPT_EE_CLAMPING_MODE,
-	"Emulation: EE/FPU Clamping Mode",
-	"EE/FPU clamping mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
-	{
-		{"0", "None"},
-		{"1", "Normal (default)"},
-		{"2", "Extra + Preserve Sign"},
-		{"3", "Full"},
-		{NULL, NULL},
-	},
-	"1" },
-
-
-	{INT_PCSX2_OPT_EE_ROUND_MODE,
-	"Emulation: EE/FPU Round Mode",
-	"EE/FPU round mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
-	{
-		{"0", "Nearest"},
-		{"1", "Negative"},
-		{"2", "Positive"},
-		{"3", "Chop/Zero (default)"},
-		{NULL, NULL},
-	},
-	"3" },
-
-
-	{ INT_PCSX2_OPT_VU_CLAMPING_MODE,
-	"Emulation: VUs Clamping Mode",
-	"VUs clamping mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
-	{
-		{"0", "None"},
-		{"1", "Normal (default)"},
-		{"2", "Extra"},
-		{"3", "Extra + Preserve Sign"},
-		{NULL, NULL},
-	},
-	"1" },
-
-
-	{ INT_PCSX2_OPT_VU_ROUND_MODE,
-	"Emulation: VUs Round Mode",
-	"VUs round mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
-	{
-		{"0", "Nearest"},
-		{"1", "Negative"},
-		{"2", "Positive"},
-		{"3", "Chop/Zero (default)"},
-		{NULL, NULL},
-	},
-	"3" },
-
-
-	{BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE,
-	"Hack: Align Sprite",
-	"Fixes vertical lines problem in some games when resolution is upscaled.",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled" },
-
-	{BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE,
-	"Hack: Merge Sprite",
-	"Another option which could fix vertical lines problem in some games when resolution is upscaled.",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled" },
-
-
-	{INT_PCSX2_OPT_USERHACK_SKIPDRAW_START,
-	"Hack: Skipdraw - Start Layer",
-	"Used to fix some rendering glitches and bad post processing by skipping rendering layers.",
-	{
-		{"0", "0 (default)"},
-		{"1", NULL},
-		{"2", NULL},
-		{"3", NULL},
-		{"4", NULL},
-		{"5", NULL},
-		{"6", NULL},
-		{"7", NULL},
-		{"8", NULL},
-		{"9", NULL},
-		{"10", NULL},
-		{"11", NULL},
-		{"12", NULL},
-		{"13", NULL},
-		{"14", NULL},
-		{"15", NULL},
-		{"16", NULL},
-		{"17", NULL},
-		{"18", NULL},
-		{"19", NULL},
-		{"20", NULL},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{INT_PCSX2_OPT_USERHACK_SKIPDRAW_LAYERS,
-	"Hack: Skipdraw - Layers to Skip",
-	"Number of rendering layers to skip, counting from the value set in the Start Layer option. For a original PCSX2 setting of 2:5, skipdraw option of the core must be set 2 +3 .",
-	{
-		{"0", "+0 (default)"},
-		{"1", "+1"},
-		{"2", "+2"},
-		{"3", "+3"},
-		{"4", "+4"},
-		{"5", "+5"},
-		{"6", "+6"},
-		{"7", "+7"},
-		{"8", "+8"},
-		{"9", "+9"},
-		{"10", "+10"},
-		{"11", "+11"},
-		{"12", "+12"},
-		{"13", "+13"},
-		{"14", "+14"},
-		{"15", "+15"},
-		{"16", "+16"},
-		{"17", "+17"},
-		{"18", "+18"},
-		{"19", "+19"},
-		{"20", "+20"},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{INT_PCSX2_OPT_USERHACK_HALFPIXEL_OFFSET,
-	"Hack: Half-pixel Offset",
-	"Might fix some misaligned fog, bloom or blend effect. The preferred option is Normal(vertex).",
-	{
-		{"0", "Off (default)"},
-		{"1", "Normal (Vertex)"},
-		{"2", "Special (Texture)"},
-		{"3", "Special (Texture-Aggessive)"},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{INT_PCSX2_OPT_USERHACK_ROUND_SPRITE,
-	"Hack: Round Sprite",
-	"Corrects the sampling of 2D textures when upscaling.",
-	{
-		{"0", "Off (default)"},
-		{"1", "Half"},
-		{"2", "Full"},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET,
-	"Hack: Wild Arms Offset",
-	"Avoid gaps between pixel in some games when upscaling.",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled" },
-
-	{INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX,
-	"Hack: Half-screen fix",
-	"Automatic control of the halfscreen fix detection on texture shuffle. Force-Disable may help in some games, but causes visual glitches in most. Use Force-Enable when a game has half screen issues.",
-	{
-		{"-1", "Automatic (default)"},
-		{"0", "Force-Disabled"},
-		{"1", "Force-Enabled"},
-		{NULL, NULL},
-	},
-	"-1" },
-
-	{BOOL_PCSX2_OPT_USERHACK_AUTO_FLUSH,
-	"Hack: Auto Flush",
-	"Force a primitive flush when a framebuffer is also an input texture. Fixes some processing effects such as the shadows in the \
-	Jak series and radiosity in GTA:SA. Very costly in performance. (Content restart required)",
-	{
-		{"disabled", NULL},
-		{"enabled", NULL},
-		{NULL, NULL},
-	},
-	"disabled" },
-
-	{BOOL_PCSX2_OPT_USERHACK_FB_CONVERSION,
-		"Hack: Frame Buffer Conversion",
-		"The hack can fix glitches in some games, like Harry Potter and Stuntman. This hack has an impact on performances. (Content restart required)",
-		{
-			{"disabled", NULL},
-			{"enabled", NULL},
-			{NULL, NULL},
-		},
-		"disabled" },
-
-	{INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_X_HUNDREDS,
-	"Hack: Texture Offset X - Hundreds",
-	"Set Texture Offset X (sum of X options Hundreds and Tens). \n Offset for the ST/UV texture coordinates. Fixes some odd texture issues and might fix some post processing alignment too.",
-	{
-		{"0", "0 (default)"},
-		{"100", "100"},
-		{"200", "200"},
-		{"300", "300"},
-		{"400", "400"},
-		{"500", "500"},
-		{"600", "600"},
-		{"700", "700"},
-		{"800", "800"},
-		{"900", "900"},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_X_TENS,
-	"Hack: Texture Offset X - Tens",
-	"Set Texture Offset X (sum of X options Hundreds and Tens). \n Offset for the ST/UV texture coordinates. Fixes some odd texture issues and might fix some post processing alignment too.",
-	{
-		{"0", "0 (default)"},
-		{"10", "10"},
-		{"20", "20"},
-		{"30", "30"},
-		{"40", "40"},
-		{"50", "50"},
-		{"60", "60"},
-		{"70", "70"},
-		{"80", "80"},
-		{"90", "90"},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_Y_HUNDREDS,
-	"Hack: Texture Offset Y - Hundreds",
-	"Set Texture Offset Y (sum of Y options Hundreds and Tens). \n Offset for the ST/UV texture coordinates. Fixes some odd texture issues and might fix some post processing alignment too.",
-	{
-		{"0", "0 (default)"},
-		{"100", "100"},
-		{"200", "200"},
-		{"300", "300"},
-		{"400", "400"},
-		{"500", "500"},
-		{"600", "600"},
-		{"700", "700"},
-		{"800", "800"},
-		{"900", "900"},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_Y_TENS,
-	"Hack: Texture Offset Y - Tens",
-	"Set Texture Offset Y (sum of Y options Hundreds and Tens). \n Offset for the ST/UV texture coordinates. Fixes some odd texture issues and might fix some post processing alignment too.",
-	{
-		{"0", "0 (default)"},
-		{"10", "10"},
-		{"20", "20"},
-		{"30", "30"},
-		{"40", "40"},
-		{"50", "50"},
-		{"60", "60"},
-		{"70", "70"},
-		{"80", "80"},
-		{"90", "90"},
-		{NULL, NULL},
-	},
-	"0" },
-
-	{NULL, NULL, NULL, {{0}}, NULL},
+struct retro_core_option_v2_category option_cats_us[] = {
+   {
+      "system_options",
+      "System",
+      "Show system options",
+   },
+   {
+      "memcards_options",
+      "Memory Cards",
+      "Show memory cards options",
+   },
+   {
+      "video_options",
+      "Video",
+      "Show video options",
+   },
+   {
+      "gamepad_options",
+      "Gamepad",
+      "Show gamepad options",
+   },
+   {
+      "emulation_options",
+      "Emulation",
+      "Show emulation options",
+   },
+   {
+      "hacks_options",
+      "Hacks",
+      "Show hacks options",
+   },
+   { NULL, NULL, NULL },
 };
+
+struct retro_core_option_v2_definition option_defs_us[] = {
+   {
+      STRING_PCSX2_OPT_BIOS,
+      "System: BIOS",
+      "BIOS",
+      NULL,
+      NULL,
+      "system_options",
+      {
+         // dynamically filled in retro_init
+      },
+      NULL
+   },
+   {
+      STRING_PCSX2_OPT_SYSTEM_LANGUAGE,
+      "System: Language",
+      "Language",
+      "Set the BIOS system Language. Useful for PAL multilanguage games. Fastboot option must be disabled. The selected language will be applied, if available in-game. (Content restart required)",
+      NULL,
+      "system_options",
+      {
+         {"English", NULL},
+         {"French", NULL},
+         {"Spanish", NULL},
+         {"German", NULL},
+         {"Italian", NULL},
+         {"Dutch", NULL},
+         {"Portuguese", NULL},
+         {NULL, NULL},
+      },
+      "English"
+   },
+   {
+      BOOL_PCSX2_OPT_FASTCDVD,
+      "System: Fast Loading",
+      "Fast Loading",
+      "A hack that reduces loading times by setting a faster disc access mode. Check the HDLoader compatibility list for games that will not work with this. (Content restart required)",
+      NULL,
+      "system_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      BOOL_PCSX2_OPT_FASTBOOT,
+      "System: Fast Boot",
+      "Fast Boot",
+      "Bypass the initial BIOS logo. (Content restart required)",
+      NULL,
+      "system_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      BOOL_PCSX2_OPT_BOOT_TO_BIOS,
+      "System: Boot to BIOS",
+      "Boot to BIOS",
+      "Skip the content loading and boot in the BIOS. Useful to manage memory cards currently associated to this content. (Content restart required)",
+      NULL,
+      "system_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      STRING_PCSX2_OPT_MEMCARD_SLOT_1,
+      "Memory Card: Slot 1",
+      "Slot 1",
+      "Select the primary memory card to use. 'Legacy' points to the memory card Mcd001 in the old location system/pcsx2/memcards. (Content restart required)",
+      NULL,
+      "memcards_options",
+      {
+         // dynamically filled in retro_init
+      },
+      NULL
+   },
+   {
+      STRING_PCSX2_OPT_MEMCARD_SLOT_2,
+      "Memory Card: Slot 2",
+      "Slot 2",
+      "Select the secondary memory card to use. 'Legacy' points to the memory card Mcd002 in the old location system/pcsx2/memcards. (Content restart required)",
+      NULL,
+      "memcards_options",
+      {
+         // dynamically filled in retro_init
+      },
+      NULL
+   },
+   {
+      STRING_PCSX2_OPT_RENDERER,
+      "Video: Renderer",
+      "Renderer",
+      "Content restart required.",
+      NULL,
+      "video_options",
+      {
+         {"Auto", NULL},
+#ifdef _WIN32
+         {"D3D11", NULL},
+#endif
+         {"OpenGL", NULL},
+         {NULL, NULL},
+      },
+      "Auto"
+   },
+   {
+      INT_PCSX2_OPT_UPSCALE_MULTIPLIER,
+      "Video: Internal Resolution",
+      "Internal Resolution",
+      NULL,
+      NULL,
+      "video_options",
+      {
+         {"1", "Native PS2"},
+         {"2", "2x Native ~720p"},
+         {"3", "3x Native ~1080p"},
+         {"4", "4x Native ~1440p 2K"},
+         {"5", "5x Native ~1620p 3K"},
+         {"6", "6x Native ~2160p 4K"},
+         {"8", "8x Native ~2880p 5K"},
+         {NULL, NULL},
+      },
+      "1"
+   },
+   {
+      INT_PCSX2_OPT_DEINTERLACING_MODE,
+      "Video: Deinterlacing Mode",
+      "Deinterlacing Mode",
+      "Can remove blur on some games. Some modes can slightly decrease performance while others can blur the whole picture, decreasing the amount of details thus deinterlacing is to be used only when it's necessary. \
+      \nNOTE: Setting this to 'No-interlacing patch' will try to apply a no-interlacing patch if available in the database. No-interlacing has the best image quality, but might not always be available for your game. (Content restart required)",
+      NULL,
+      "video_options",
+      {
+         {"7", "Automatic (default)"},
+         {"6", "Blend bff - slight blur, 1/2 fps"},
+         {"5", "Blend tff - slight blur, 1/2 fps"},
+         {"4", "Bob bff - use blend if shaking"},
+         {"3", "Bob tff - use blend if shaking"},
+         {"2", "Weave bff - saw-tooth"},
+         {"1", "Weave tff - saw-tooth"},
+         {"0", "None "},
+         {"-1","No-interlacing patch"},
+         {NULL, NULL},
+      },
+      "7"
+   },
+   {
+      INT_PCSX2_OPT_ASPECT_RATIO,
+      "Video: Aspect Ratio",
+      "Aspect Ratio",
+      "Sets the aspect ratio. Setting the aspect ratio to Widescreen (16:9) stretches the display. For proper widescreen in select games, also turn on the 'Enable Widescreen Patches' option. (Content restart required)",
+      NULL,
+      "video_options",
+      {
+         {"0", "Standard (4:3)"},
+         {"1", "Widescreen (16:9)"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      BOOL_PCSX2_OPT_ENABLE_WIDESCREEN_PATCHES,
+      "Video: Enable Widescreen Patches",
+      "Enable Widescreen Patches",
+      "Enables widescreen patches that allow certain games to render in true 16:9 ratio without stretching the display. For the widescreen patches to display properly, the 'Aspect Ratio' option should be set to 'Widescreen (16:9)'. (Content restart required)",
+      NULL,
+      "video_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      BOOL_PCSX2_OPT_ENABLE_60FPS_PATCHES,
+      "Video: Enable 60fps Patches",
+      "Enable 60fps Patches",
+      "Enables 60fps patches that allow certain games to run at higher framerates than the original framerate. NOTE: No guarantees about stability or game bugs, use at your own caution. (Content restart required)",
+      NULL,
+      "video_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      INT_PCSX2_OPT_FXAA,
+      "Video: FXAA",
+      "FXAA",
+      "Enables Fast Approximate Anti-Aliasing.",
+      NULL,
+      "video_options",
+      {
+         {"0", "Disabled"},
+         {"1", "Enabled"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      INT_PCSX2_OPT_ANISOTROPIC_FILTER,
+      "Video: Anisotropic Filtering",
+      "Anisotropic Filtering",
+      "Reduces texture aliasing at extreme viewing angles.",
+      NULL,
+      "video_options",
+      {
+         {"0", "None"},
+         {"2", "2x"},
+         {"4", "4x"},
+         {"8", "8x"},
+         {"16", "16x"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      INT_PCSX2_OPT_DITHERING,
+      "Video: Dithering",
+      "Dithering",
+      "Disabling dithering can remove some noise and pixelate effects.",
+      NULL,
+      "video_options",
+      {
+         {"0", "Off"},
+         {"1", "Scaled"},
+         {"2", "Unscaled (default)"},
+         {NULL, NULL},
+      },
+      "2"
+   },
+   {
+      INT_PCSX2_OPT_TEXTURE_FILTERING,
+      "Video: Texture Filtering",
+      "Texture Filtering",
+      "Controls the texture filtering of the emulation. \
+      \n'Nearest': always disable interpolation, rendering will be blocky. \
+      \n'Bilinear (Forced)': always enable interpolation. Rendering is smoother but it could generate some glitches. \
+      \n'Bilinear (PS2)': use same mode as the PS2. It is the more accurate option. \
+      \n'Bilinear (Forced Excluding Sprite)': always enable interpolation except for sprites (FMV/Text/2D elements). Rendering is smoother but it could generate a few glitches. If upscaling is enabled, this setting is recommended over 'Bilinear (Forced)'.",
+      NULL,
+      "video_options",
+      {
+         {"0", "Nearest"},
+         {"1", "Bilinear (Forced)"},
+         {"2", "Bilinear (PS2 - Default)"},
+         {"3", "Bilinear (Forced Excluding Sprite)"},
+         {NULL, NULL},
+      },
+      "2"
+   },
+   {
+      INT_PCSX2_OPT_MIPMAPPING,
+      "Video: Mipmapping",
+      "Mipmapping",
+      "Control the accuracy level of the mipmapping emulation. \
+      \n'Automatic': Automatically sets the mipmapping level based on the game. This is the recommended setting. \
+      \n'Off': Mipmapping emulation is disabled. \
+      \n'Basic' (Fast): Partially emulates mipmapping, performance impact is negligible in most cases. \
+      \n'Full' (Slow):  Completely emulates the mipmapping function of the GS, might significantly impact performance.",
+      NULL,
+      "video_options",
+      {
+         {"-1", "Automatic (default)"},
+         {"0", "Off"},
+         {"1", "Basic"},
+         {"2", "Full"},
+   
+         {NULL, NULL},
+      },
+      "-1"
+   },
+   {
+      BOOL_PCSX2_OPT_CONSERVATIVE_BUFFER,
+      "Video: Conservative Buffer Allocation",
+      "Conservative Buffer Allocation",
+      "Disabled: Reserves a larger framebuffer to prevent FMV flickers. Increases GPU/memory requirements. \
+      \nDisabling this can amplify stuttering due to low RAM/VRAM. \
+      \nNote: It should be enabled for Armored Core, Destroy All Humans, Gran Turismo and possibly others. \
+      \nThis option does not improve the graphics or the FPS.",
+      NULL,
+      "video_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "enabled"
+   },
+   {
+      BOOL_PCSX2_OPT_ACCURATE_DATE,
+      "Video: Accurate DATE",
+      "Accurate DATE",
+      "Implement a more accurate algorithm to compute GS destination alpha testing. It improves shadow and transparency rendering. \
+      \nNote: Direct3D 11 is less accurate.",
+      NULL,
+      "video_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "enabled"
+   },
+   {
+      BOOL_PCSX2_OPT_FRAMESKIP,
+      "Video: Frame Skip",
+      "Frame Skip",
+      NULL,
+      NULL,
+      "video_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      INT_PCSX2_OPT_FRAMES_TO_DRAW,
+      "Video: Frameskip - Frames to Draw",
+      "Frameskip - Frames to Draw",
+      NULL,
+      NULL,
+      "video_options",
+      {
+         {"1", NULL},
+         {"2", NULL},
+         {"3", NULL},
+         {"4", NULL},
+         {"5", NULL},
+         {"6", NULL},
+         {"7", NULL},
+         {"8", NULL},
+         {"9", NULL},
+         {"10", NULL},
+         {NULL, NULL},
+      },
+      "1"
+   },
+   {
+      INT_PCSX2_OPT_FRAMES_TO_SKIP,
+      "Video: Frameskip - Frames to Skip",
+      "Frameskip - Frames to Skip",
+      NULL,
+      NULL,
+      "video_options",
+      {
+         {"1", NULL},
+         {"2", NULL},
+         {"3", NULL},
+         {"4", NULL},
+         {"5", NULL},
+         {"6", NULL},
+         {"7", NULL},
+         {"8", NULL},
+         {"9", NULL},
+         {"10", NULL},
+         {NULL, NULL},
+      },
+      "1"
+   },
+   {
+      BOOL_PCSX2_OPT_GAMEPAD_RUMBLE_ENABLE,
+      "Gamepad: Enable Rumble",
+      "Enable Rumble",
+      "Enables rumble on gamepads that support it.",
+      NULL,
+      "gamepad_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "enabled"
+   },
+   {
+      INT_PCSX2_OPT_GAMEPAD_RUMBLE_FORCE,
+      "Gamepad: Rumble Intensity",
+      "Rumble Intensity",
+      "Intensity of gamepad rumble.",
+      NULL,
+      "gamepad_options",
+      {
+         {"10", "10%"},
+         {"20", "20%"},
+         {"30", "30%"},
+         {"40", "40%"},
+         {"50", "50%"},
+         {"60", "60%"},
+         {"70", "70%"},
+         {"80", "80%"},
+         {"90", "90%"},
+         {"100", "100%"},
+         {NULL, NULL},
+      },
+      "100"
+   },
+   {
+      INT_PCSX2_OPT_GAMEPAD_L_DEADZONE,
+      "Gamepad: Left Stick Dead Zone",
+      "Left Stick Dead Zone",
+      "Set the dead zone of left thumbstick.",
+      NULL,
+      "gamepad_options",
+      {
+         {"0", "No Dead Zone (default)"},
+         {"1", "1%"},
+         {"2", "2%"},
+         {"3", "3%"},
+         {"4", "4%"},
+         {"5", "5%"},
+         {"6", "6%"},
+         {"7", "7%"},
+         {"8", "8%"},
+         {"9", "9%"},
+         {"10", "10%"},
+         {"11", "11%"},
+         {"12", "12%"},
+         {"13", "13%"},
+         {"14", "14%"},
+         {"15", "15%"},
+         {"16", "16%"},
+         {"17", "17%"},
+         {"18", "18%"},
+         {"19", "19%"},
+         {"20", "20%"},
+         {"21", "21%"},
+         {"22", "22%"},
+         {"23", "23%"},
+         {"24", "24%"},
+         {"25", "25%"},
+         {"26", "26%"},
+         {"27", "27%"},
+         {"28", "28%"},
+         {"29", "29%"},
+         {"30", "30%"},
+         {"31", "31%"},
+         {"32", "32%"},
+         {"33", "33%"},
+         {"34", "34%"},
+         {"35", "35%"},
+         {"36", "36%"},
+         {"37", "37%"},
+         {"38", "38%"},
+         {"39", "39%"},
+         {"40", "40%"},
+         {"41", "41%"},
+         {"42", "42%"},
+         {"43", "43%"},
+         {"44", "44%"},
+         {"45", "45%"},
+         {"46", "46%"},
+         {"47", "47%"},
+         {"48", "48%"},
+         {"49", "49%"},
+         {"50", "50%"},
+         {NULL, NULL},
+      },
+      "enabled"
+   },
+   {
+      INT_PCSX2_OPT_GAMEPAD_R_DEADZONE,
+      "Gamepad: Right Stick Dead Zone",
+      "Right Stick Dead Zone",
+      "Set the dead zone of right thumbstick.",
+      NULL,
+      "gamepad_options",
+      {
+         {"0", "No Dead Zone (default)"},
+         {"1", "1%"},
+         {"2", "2%"},
+         {"3", "3%"},
+         {"4", "4%"},
+         {"5", "5%"},
+         {"6", "6%"},
+         {"7", "7%"},
+         {"8", "8%"},
+         {"9", "9%"},
+         {"10", "10%"},
+         {"11", "11%"},
+         {"12", "12%"},
+         {"13", "13%"},
+         {"14", "14%"},
+         {"15", "15%"},
+         {"16", "16%"},
+         {"17", "17%"},
+         {"18", "18%"},
+         {"19", "19%"},
+         {"20", "20%"},
+         {"21", "21%"},
+         {"22", "22%"},
+         {"23", "23%"},
+         {"24", "24%"},
+         {"25", "25%"},
+         {"26", "26%"},
+         {"27", "27%"},
+         {"28", "28%"},
+         {"29", "29%"},
+         {"30", "30%"},
+         {"31", "31%"},
+         {"32", "32%"},
+         {"33", "33%"},
+         {"34", "34%"},
+         {"35", "35%"},
+         {"36", "36%"},
+         {"37", "37%"},
+         {"38", "38%"},
+         {"39", "39%"},
+         {"40", "40%"},
+         {"41", "41%"},
+         {"42", "42%"},
+         {"43", "43%"},
+         {"44", "44%"},
+         {"45", "45%"},
+         {"46", "46%"},
+         {"47", "47%"},
+         {"48", "48%"},
+         {"49", "49%"},
+         {"50", "50%"},
+         {NULL, NULL},
+      },
+      "enabled"
+   },
+   {
+      BOOL_PCSX2_OPT_ENABLE_CHEATS,
+      "Emulation: Enable Cheats",
+      "Enable Cheats",
+      "Enabled: Checks the 'system/pcsx2/cheats' directory for a PNACH file for the running content and, if found, applies the cheats from the file. (Content restart required)",
+      NULL,
+      "emulation_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      INT_PCSX2_OPT_SPEEDHACKS_PRESET,
+      "Emulation: Speed Hacks Preset",
+      "Speed Hacks Preset",
+      "Preset which controls the balance between accuracy and speed. (Content restart required) \
+      \n'Safest': no speed hacks. Most reliable, but possibly slow. \
+      \n'Safe': a few speed hacks known to provide boosts with minimal to no side effects. \
+      \n'Balanced': recommended preset for CPUs with 4+ cores. Provides good boosts with minimal to no side effects. \
+      \n'Aggressive'/'Very Aggressive': may help underpowered CPUs in less demanding games, but may cause problems in other cases. \
+      \n'Mostly Harmful': helps a very small set of games with unusual performance requirements. Not recommended for underpowered devices.",
+      NULL,
+      "emulation_options",
+      {
+         {"0", "Safest - No Hacks"},
+         {"1", "Safe (default)"},
+         {"2", "Balanced"},
+         {"3", "Aggressive"},
+         {"4", "Very Aggressive"},
+         {"5", "Mostly Harmful"},
+         {NULL, NULL},
+      },
+      "1"
+   },
+   {
+      INT_PCSX2_OPT_VSYNC_MTGS_QUEUE,
+      "Emulation: Vsyncs in MTGS Queue",
+      "Vsyncs in MTGS Queue",
+      "Setting this to a lower value improves input lag, a value around 2 or 3 will slightly improve framerates.",
+      NULL,
+      "emulation_options",
+      {
+         {"0", "0"},
+         {"1", "1"},
+         {"2", "2 (default)"},
+         {"3", "3"},
+         {NULL, NULL},
+      },
+      "2"
+   },
+   {
+      INT_PCSX2_OPT_EE_CLAMPING_MODE,
+      "Emulation: EE/FPU Clamping Mode",
+      "EE/FPU Clamping Mode",
+      "EE/FPU clamping mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
+      NULL,
+      "emulation_options",
+      {
+         {"0", "None"},
+         {"1", "Normal (default)"},
+         {"2", "Extra + Preserve Sign"},
+         {"3", "Full"},
+         {NULL, NULL},
+      },
+      "1"
+   },
+   {
+      INT_PCSX2_OPT_EE_ROUND_MODE,
+      "Emulation: EE/FPU Round Mode",
+      "EE/FPU Round Mode",
+      "EE/FPU round mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
+      NULL,
+      "emulation_options",
+      {
+         {"0", "Nearest"},
+         {"1", "Negative"},
+         {"2", "Positive"},
+         {"3", "Chop/Zero (default)"},
+         {NULL, NULL},
+      },
+      "3"
+   },
+   {
+      INT_PCSX2_OPT_VU_CLAMPING_MODE,
+      "Emulation: VUs Clamping Mode",
+      "VUs Clamping Mode",
+      "VUs clamping mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
+      NULL,
+      "emulation_options",
+      {
+         {"0", "None"},
+         {"1", "Normal (default)"},
+         {"2", "Extra"},
+         {"3", "Extra + Preserve Sign"},
+         {NULL, NULL},
+      },
+      "1"
+   },
+   {
+      INT_PCSX2_OPT_VU_ROUND_MODE,
+      "Emulation: VUs Round Mode",
+      "VUs Round Mode",
+      "VUs round mode can fix some bugs on some games. Default value is fine for most games. (Content restart required)",
+      NULL,
+      "emulation_options",
+      {
+         {"0", "Nearest"},
+         {"1", "Negative"},
+         {"2", "Positive"},
+         {"3", "Chop/Zero (default)"},
+         {NULL, NULL},
+      },
+      "3"
+   },
+   {
+      BOOL_PCSX2_OPT_USERHACK_ALIGN_SPRITE,
+      "Hack: Align Sprite",
+      "Align Sprite",
+      "Fixes vertical lines problem in some games when resolution is upscaled.",
+      NULL,
+      "hacks_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      BOOL_PCSX2_OPT_USERHACK_MERGE_SPRITE,
+      "Hack: Merge Sprite",
+      "Merge Sprite",
+      "Another option which could fix vertical lines problem in some games when resolution is upscaled.",
+      NULL,
+      "hacks_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      INT_PCSX2_OPT_USERHACK_SKIPDRAW_START,
+      "Hack: Skipdraw - Start Layer",
+      "Skipdraw - Start Layer",
+      "Used to fix some rendering glitches and bad post processing by skipping rendering layers.",
+      NULL,
+      "hacks_options",
+      {
+         {"0", "0 (default)"},
+         {"1", NULL},
+         {"2", NULL},
+         {"3", NULL},
+         {"4", NULL},
+         {"5", NULL},
+         {"6", NULL},
+         {"7", NULL},
+         {"8", NULL},
+         {"9", NULL},
+         {"10", NULL},
+         {"11", NULL},
+         {"12", NULL},
+         {"13", NULL},
+         {"14", NULL},
+         {"15", NULL},
+         {"16", NULL},
+         {"17", NULL},
+         {"18", NULL},
+         {"19", NULL},
+         {"20", NULL},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      INT_PCSX2_OPT_USERHACK_SKIPDRAW_LAYERS,
+      "Hack: Skipdraw - Layers to Skip",
+      "Skipdraw - Layers to Skip",
+      "Number of rendering layers to skip, counting from the value set in the Start Layer option. For a original PCSX2 setting of 2:5, skipdraw option of the core must be set 2 +3.",
+      NULL,
+      "hacks_options",
+      {
+         {"0", "+0 (default)"},
+         {"1", "+1"},
+         {"2", "+2"},
+         {"3", "+3"},
+         {"4", "+4"},
+         {"5", "+5"},
+         {"6", "+6"},
+         {"7", "+7"},
+         {"8", "+8"},
+         {"9", "+9"},
+         {"10", "+10"},
+         {"11", "+11"},
+         {"12", "+12"},
+         {"13", "+13"},
+         {"14", "+14"},
+         {"15", "+15"},
+         {"16", "+16"},
+         {"17", "+17"},
+         {"18", "+18"},
+         {"19", "+19"},
+         {"20", "+20"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      INT_PCSX2_OPT_USERHACK_HALFPIXEL_OFFSET,
+      "Hack: Half-pixel Offset",
+      "Half-pixel Offset",
+      "Might fix some misaligned fog, bloom or blend effect. The preferred option is 'Normal (Vertex)'.",
+      NULL,
+      "hacks_options",
+      {
+         {"0", "Off (default)"},
+         {"1", "Normal (Vertex)"},
+         {"2", "Special (Texture)"},
+         {"3", "Special (Texture-Aggessive)"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      INT_PCSX2_OPT_USERHACK_ROUND_SPRITE,
+      "Hack: Round Sprite",
+      "Round Sprite",
+      "Corrects the sampling of 2D textures when upscaling.",
+      NULL,
+      "hacks_options",
+      {
+         {"0", "Off (default)"},
+         {"1", "Half"},
+         {"2", "Full"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      BOOL_PCSX2_OPT_USERHACK_WILDARMS_OFFSET,
+      "Hack: Wild Arms Offset",
+      "Wild Arms Offset",
+      "Avoid gaps between pixel in some games when upscaling.",
+      NULL,
+      "hacks_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      INT_PCSX2_OPT_USERHACK_HALFSCREEN_FIX,
+      "Hack: Half-screen fix",
+      "Half-screen fix",
+      "Automatic control of the halfscreen fix detection on texture shuffle. 'Force-Disabled' may help in some games, but causes visual glitches in most. Use 'Force-Enabled' when a game has half screen issues.",
+      NULL,
+      "hacks_options",
+      {
+         {"-1", "Automatic (default)"},
+         {"0", "Force-Disabled"},
+         {"1", "Force-Enabled"},
+         {NULL, NULL},
+      },
+      "-1"
+   },
+   {
+      BOOL_PCSX2_OPT_USERHACK_AUTO_FLUSH,
+      "Hack: Auto Flush",
+      "Auto Flush",
+      "Force a primitive flush when a framebuffer is also an input texture. Fixes some processing effects such as the shadows in the Jak series and radiosity in GTA:SA. \
+      \nVery costly in performance. (Content restart required)",
+      NULL,
+      "hacks_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      BOOL_PCSX2_OPT_USERHACK_FB_CONVERSION,
+      "Hack: Frame Buffer Conversion",
+      "Frame Buffer Conversion",
+      "The hack can fix glitches in some games, like Harry Potter and Stuntman. This hack has an impact on performances. (Content restart required)",
+      NULL,
+      "hacks_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
+      INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_X_HUNDREDS,
+      "Hack: Texture Offset X - Hundreds",
+      "Texture Offset X - Hundreds",
+      "Set Texture Offset X (sum of X options Hundreds and Tens). \
+      \nOffset for the ST/UV texture coordinates. Fixes some odd texture issues and might fix some post processing alignment too.",
+      NULL,
+      "hacks_options",
+      {
+         {"0", "0 (default)"},
+         {"100", "100"},
+         {"200", "200"},
+         {"300", "300"},
+         {"400", "400"},
+         {"500", "500"},
+         {"600", "600"},
+         {"700", "700"},
+         {"800", "800"},
+         {"900", "900"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_X_TENS,
+      "Hack: Texture Offset X - Tens",
+      "Texture Offset X - Tens",
+      "Set Texture Offset X (sum of X options Hundreds and Tens). \
+      \nOffset for the ST/UV texture coordinates. Fixes some odd texture issues and might fix some post processing alignment too.",
+      NULL,
+      "hacks_options",
+      {
+         {"0", "0 (default)"},
+         {"10", "10"},
+         {"20", "20"},
+         {"30", "30"},
+         {"40", "40"},
+         {"50", "50"},
+         {"60", "60"},
+         {"70", "70"},
+         {"80", "80"},
+         {"90", "90"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_Y_HUNDREDS,
+      "Hack: Texture Offset Y - Hundreds",
+      "Texture Offset Y - Hundreds",
+      "Set Texture Offset Y (sum of Y options Hundreds and Tens). \
+      \nOffset for the ST/UV texture coordinates. Fixes some odd texture issues and might fix some post processing alignment too.",
+      NULL,
+      "hacks_options",
+      {
+         {"0", "0 (default)"},
+         {"100", "100"},
+         {"200", "200"},
+         {"300", "300"},
+         {"400", "400"},
+         {"500", "500"},
+         {"600", "600"},
+         {"700", "700"},
+         {"800", "800"},
+         {"900", "900"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   {
+      INT_PCSX2_OPT_USERHACK_TEXTURE_OFFSET_Y_TENS,
+      "Hack: Texture Offset Y - Tens",
+      "Texture Offset Y - Tens",
+      "Set Texture Offset Y (sum of Y options Hundreds and Tens). \
+      \nOffset for the ST/UV texture coordinates. Fixes some odd texture issues and might fix some post processing alignment too.",
+      NULL,
+      "hacks_options",
+      {
+         {"0", "0 (default)"},
+         {"10", "10"},
+         {"20", "20"},
+         {"30", "30"},
+         {"40", "40"},
+         {"50", "50"},
+         {"60", "60"},
+         {"70", "70"},
+         {"80", "80"},
+         {"90", "90"},
+         {NULL, NULL},
+      },
+      "0"
+   },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+
+struct retro_core_options_v2 options_us = {
+   option_cats_us,
+   option_defs_us
+};
+
+/*
+ ********************************
+ * Language Mapping
+ ********************************
+*/
+
+#ifndef HAVE_NO_LANGEXTRA
+struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
+   &options_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,        /* RETRO_LANGUAGE_JAPANESE */
+   NULL,        /* RETRO_LANGUAGE_FRENCH */
+   NULL,        /* RETRO_LANGUAGE_SPANISH */
+   NULL,        /* RETRO_LANGUAGE_GERMAN */
+   NULL,        /* RETRO_LANGUAGE_ITALIAN */
+   NULL,        /* RETRO_LANGUAGE_DUTCH */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,        /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,        /* RETRO_LANGUAGE_KOREAN */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,        /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,        /* RETRO_LANGUAGE_POLISH */
+   NULL,        /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,        /* RETRO_LANGUAGE_ARABIC */
+   NULL,        /* RETRO_LANGUAGE_GREEK */
+   NULL,        /* RETRO_LANGUAGE_TURKISH */
+   NULL,        /* RETRO_LANGUAGE_SLOVAK */
+   NULL,        /* RETRO_LANGUAGE_PERSIAN */
+   NULL,        /* RETRO_LANGUAGE_HEBREW */
+   NULL,        /* RETRO_LANGUAGE_ASTURIAN */
+   NULL,        /* RETRO_LANGUAGE_FINNISH */
+};
+#endif
 
 /*
  ********************************
@@ -766,132 +1071,275 @@ struct retro_core_option_definition option_defs[] = {
  *   be as painless as possible for core devs)
  */
 
-static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
+      bool *categories_supported)
 {
-	unsigned version = 0;
+   unsigned version  = 0;
+#ifndef HAVE_NO_LANGEXTRA
+   unsigned language = 0;
+#endif
 
-	if (!environ_cb)
-		return;
+   if (!environ_cb || !categories_supported)
+      return;
 
-	if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
-	{
-		environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, &option_defs);
-	}
-	else
-	{
-		size_t i;
-		size_t num_options = 0;
-		struct retro_variable* variables = NULL;
-		char** values_buf = NULL;
+   *categories_supported = false;
 
-		/* Determine number of options */
-		while (true)
-		{
-			if (option_defs[num_options].key)
-				num_options++;
-			else
-				break;
-		}
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
+      version = 0;
 
-		/* Allocate arrays */
-		variables = (struct retro_variable*)calloc(num_options + 1, sizeof(struct retro_variable));
-		values_buf = (char**)calloc(num_options, sizeof(char*));
+   if (version >= 2)
+   {
+#ifndef HAVE_NO_LANGEXTRA
+      struct retro_core_options_v2_intl core_options_intl;
 
-		if (!variables || !values_buf)
-			goto error;
+      core_options_intl.us    = &options_us;
+      core_options_intl.local = NULL;
 
-		/* Copy parameters from option_defs array */
-		for (i = 0; i < num_options; i++)
-		{
-			const char* key = option_defs[i].key;
-			const char* desc = option_defs[i].desc;
-			const char* default_value = option_defs[i].default_value;
-			struct retro_core_option_value* values = option_defs[i].values;
-			size_t buf_len = 3;
-			size_t default_index = 0;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+          (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
+         core_options_intl.local = options_intl[language];
 
-			values_buf[i] = NULL;
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL,
+            &core_options_intl);
+#else
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+            &options_us);
+#endif
+   }
+   else
+   {
+      size_t i, j;
+      size_t option_index              = 0;
+      size_t num_options               = 0;
+      struct retro_core_option_definition
+            *option_v1_defs_us         = NULL;
+#ifndef HAVE_NO_LANGEXTRA
+      size_t num_options_intl          = 0;
+      struct retro_core_option_v2_definition
+            *option_defs_intl          = NULL;
+      struct retro_core_option_definition
+            *option_v1_defs_intl       = NULL;
+      struct retro_core_options_intl
+            core_options_v1_intl;
+#endif
+      struct retro_variable *variables = NULL;
+      char **values_buf                = NULL;
 
-			if (desc)
-			{
-				size_t num_values = 0;
+      /* Determine total number of options */
+      while (true)
+      {
+         if (option_defs_us[num_options].key)
+            num_options++;
+         else
+            break;
+      }
 
-				/* Determine number of values */
-				while (true)
-				{
-					if (values[num_values].value)
-					{
-						/* Check if this is the default value */
-						if (default_value)
-							if (strcmp(values[num_values].value, default_value) == 0)
-								default_index = num_values;
+      if (version >= 1)
+      {
+         /* Allocate US array */
+         option_v1_defs_us = (struct retro_core_option_definition *)
+               calloc(num_options + 1, sizeof(struct retro_core_option_definition));
 
-						buf_len += strlen(values[num_values].value);
-						num_values++;
-					}
-					else
-						break;
-				}
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            struct retro_core_option_v2_definition *option_def_us = &option_defs_us[i];
+            struct retro_core_option_value *option_values         = option_def_us->values;
+            struct retro_core_option_definition *option_v1_def_us = &option_v1_defs_us[i];
+            struct retro_core_option_value *option_v1_values      = option_v1_def_us->values;
 
-				/* Build values string */
-				if (num_values > 0)
-				{
-					size_t j;
+            option_v1_def_us->key           = option_def_us->key;
+            option_v1_def_us->desc          = option_def_us->desc;
+            option_v1_def_us->info          = option_def_us->info;
+            option_v1_def_us->default_value = option_def_us->default_value;
 
-					buf_len += num_values - 1;
-					buf_len += strlen(desc);
+            /* Values must be copied individually... */
+            while (option_values->value)
+            {
+               option_v1_values->value = option_values->value;
+               option_v1_values->label = option_values->label;
 
-					values_buf[i] = (char*)calloc(buf_len, sizeof(char));
-					if (!values_buf[i])
-						goto error;
+               option_values++;
+               option_v1_values++;
+            }
+         }
 
-					strcpy(values_buf[i], desc);
-					strcat(values_buf[i], "; ");
+#ifndef HAVE_NO_LANGEXTRA
+         if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+             (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH) &&
+             options_intl[language])
+            option_defs_intl = options_intl[language]->definitions;
 
-					/* Default value goes first */
-					strcat(values_buf[i], values[default_index].value);
+         if (option_defs_intl)
+         {
+            /* Determine number of intl options */
+            while (true)
+            {
+               if (option_defs_intl[num_options_intl].key)
+                  num_options_intl++;
+               else
+                  break;
+            }
 
-					/* Add remaining values */
-					for (j = 0; j < num_values; j++)
-					{
-						if (j != default_index)
-						{
-							strcat(values_buf[i], "|");
-							strcat(values_buf[i], values[j].value);
-						}
-					}
-				}
-			}
+            /* Allocate intl array */
+            option_v1_defs_intl = (struct retro_core_option_definition *)
+                  calloc(num_options_intl + 1, sizeof(struct retro_core_option_definition));
 
-			variables[i].key = key;
-			variables[i].value = values_buf[i];
-		}
+            /* Copy parameters from option_defs_intl array */
+            for (i = 0; i < num_options_intl; i++)
+            {
+               struct retro_core_option_v2_definition *option_def_intl = &option_defs_intl[i];
+               struct retro_core_option_value *option_values           = option_def_intl->values;
+               struct retro_core_option_definition *option_v1_def_intl = &option_v1_defs_intl[i];
+               struct retro_core_option_value *option_v1_values        = option_v1_def_intl->values;
 
-		/* Set variables */
-		environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+               option_v1_def_intl->key           = option_def_intl->key;
+               option_v1_def_intl->desc          = option_def_intl->desc;
+               option_v1_def_intl->info          = option_def_intl->info;
+               option_v1_def_intl->default_value = option_def_intl->default_value;
 
-	error:
+               /* Values must be copied individually... */
+               while (option_values->value)
+               {
+                  option_v1_values->value = option_values->value;
+                  option_v1_values->label = option_values->label;
 
-		/* Clean up */
-		if (values_buf)
-		{
-			for (i = 0; i < num_options; i++)
-			{
-				if (values_buf[i])
-				{
-					free(values_buf[i]);
-					values_buf[i] = NULL;
-				}
-			}
+                  option_values++;
+                  option_v1_values++;
+               }
+            }
+         }
 
-			free(values_buf);
-			values_buf = NULL;
-		}
+         core_options_v1_intl.us    = option_v1_defs_us;
+         core_options_v1_intl.local = option_v1_defs_intl;
 
-		if (variables)
-		{
-			free(variables);
-			variables = NULL;
-		}
-	}
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_v1_intl);
+#else
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_v1_defs_us);
+#endif
+      }
+      else
+      {
+         /* Allocate arrays */
+         variables  = (struct retro_variable *)calloc(num_options + 1,
+               sizeof(struct retro_variable));
+         values_buf = (char **)calloc(num_options, sizeof(char *));
+
+         if (!variables || !values_buf)
+            goto error;
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            const char *key                        = option_defs_us[i].key;
+            const char *desc                       = option_defs_us[i].desc;
+            const char *default_value              = option_defs_us[i].default_value;
+            struct retro_core_option_value *values = option_defs_us[i].values;
+            size_t buf_len                         = 3;
+            size_t default_index                   = 0;
+
+            values_buf[i] = NULL;
+
+            if (desc)
+            {
+               size_t num_values = 0;
+
+               /* Determine number of values */
+               while (true)
+               {
+                  if (values[num_values].value)
+                  {
+                     /* Check if this is the default value */
+                     if (default_value)
+                        if (strcmp(values[num_values].value, default_value) == 0)
+                           default_index = num_values;
+
+                     buf_len += strlen(values[num_values].value);
+                     num_values++;
+                  }
+                  else
+                     break;
+               }
+
+               /* Build values string */
+               if (num_values > 0)
+               {
+                  buf_len += num_values - 1;
+                  buf_len += strlen(desc);
+
+                  values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+                  if (!values_buf[i])
+                     goto error;
+
+                  strcpy(values_buf[i], desc);
+                  strcat(values_buf[i], "; ");
+
+                  /* Default value goes first */
+                  strcat(values_buf[i], values[default_index].value);
+
+                  /* Add remaining values */
+                  for (j = 0; j < num_values; j++)
+                  {
+                     if (j != default_index)
+                     {
+                        strcat(values_buf[i], "|");
+                        strcat(values_buf[i], values[j].value);
+                     }
+                  }
+               }
+            }
+
+            variables[option_index].key   = key;
+            variables[option_index].value = values_buf[i];
+            option_index++;
+         }
+
+         /* Set variables */
+         environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+      }
+
+error:
+      /* Clean up */
+
+      if (option_v1_defs_us)
+      {
+         free(option_v1_defs_us);
+         option_v1_defs_us = NULL;
+      }
+
+#ifndef HAVE_NO_LANGEXTRA
+      if (option_v1_defs_intl)
+      {
+         free(option_v1_defs_intl);
+         option_v1_defs_intl = NULL;
+      }
+#endif
+
+      if (values_buf)
+      {
+         for (i = 0; i < num_options; i++)
+         {
+            if (values_buf[i])
+            {
+               free(values_buf[i]);
+               values_buf[i] = NULL;
+            }
+         }
+
+         free(values_buf);
+         values_buf = NULL;
+      }
+
+      if (variables)
+      {
+         free(variables);
+         variables = NULL;
+      }
+   }
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -1,0 +1,91 @@
+﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
+
+#include <libretro.h>
+
+/*
+ ********************************
+ * VERSION: 2.0
+ ********************************
+ *
+ * - 2.0: Add support for core options v2 interface
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+/* RETRO_LANGUAGE_SLOVAK */
+
+/* RETRO_LANGUAGE_PERSIAN */
+
+/* RETRO_LANGUAGE_HEBREW */
+
+/* RETRO_LANGUAGE_ASTURIAN */
+
+/* RETRO_LANGUAGE_FINNISH */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -53,6 +53,7 @@ static struct retro_perf_callback perf_cb;
 #define RETRO_PERFORMANCE_STOP(name)
 #endif
 
+static bool libretro_supports_option_categories = false;
 static bool init_failed = false;
 int option_upscale_mult = 1;
 int option_pad_left_deadzone = 0;
@@ -213,7 +214,7 @@ void retro_init(void)
 	//
 	// Per game folders saves has been disabled because hangs while writing on disk
 	// and seems not working well on some games
-	for (retro_core_option_definition& def : option_defs)
+	for (retro_core_option_v2_definition& def : option_defs_us)
 	{								
 		if (!def.key || strcmp(def.key, "pcsx2_memcard_slot_1")) continue; 
 		size_t i = 0;
@@ -236,7 +237,7 @@ void retro_init(void)
 		break;
 	}
 
-	for (retro_core_option_definition& def : option_defs)
+	for (retro_core_option_v2_definition& def : option_defs_us)
 	{
 		if (!def.key || strcmp(def.key, "pcsx2_memcard_slot_2")) continue; 
 		size_t i = 0;
@@ -287,7 +288,7 @@ void retro_init(void)
 	}
 
 
-	for (retro_core_option_definition& def : option_defs)
+	for (retro_core_option_v2_definition& def : option_defs_us)
 	{
 		if (!def.key || strcmp(def.key, "pcsx2_bios")) continue;
 		size_t i = 0, numfiles = bios_files.size();
@@ -305,7 +306,9 @@ void retro_init(void)
 
 	// loads the options structure to the frontend
 
-	libretro_set_core_options(environ_cb);
+	libretro_supports_option_categories = false;
+	libretro_set_core_options(environ_cb,
+		&libretro_supports_option_categories);
 
 	// start init some core settings
 
@@ -423,6 +426,8 @@ void retro_init(void)
 
 void retro_deinit(void)
 {
+	libretro_supports_option_categories = false;
+
 	/* FIXME: This is a workaround that resolves crashes on close content.
 	When closing the frontend, we end up with a zombie process because the
 	main thread tries to call vu1Thread.Cancel() within pcsx2's destructor


### PR DESCRIPTION
I was tired of that HUGE list of core options so I added categories:

![image](https://user-images.githubusercontent.com/33353403/144658565-0c76b90c-9856-4378-a141-46cfb9726e11.png)

And inside the "System" category as an example:

![image](https://user-images.githubusercontent.com/33353403/144658585-d92162cd-b149-42ae-b8f2-858bcdf80f0b.png)

This is what I did:

* `libretro.h`: updated with https://github.com/libretro/RetroArch/tree/master/libretro-common/include/libretro.h
* `libretro_core_options.h`: grabbed from https://github.com/libretro/RetroArch/tree/master/libretro-common/samples/core_options/example_categories then I replaced the examples with the PCSX2 core options (updated with categories), this part took me forever :p 
* `libretro_core_options_intl.h`: grabbed from the same link and removed the examples as well.
* `main.cpp`: replaced the 3 instances of
    ```cpp
    for (retro_core_option_definition& def : option_defs)
    ```
    with
    ```cpp
    for (retro_core_option_v2_definition& def : option_defs_us)
    ```
    and based on https://github.com/libretro/gambatte-libretro/pull/194 , I replaced
    ```cpp
    libretro_set_core_options(environ_cb);
    ```
    with
    ```cpp
    libretro_supports_option_categories = false;
    libretro_set_core_options(environ_cb,
    	&libretro_supports_option_categories);
    ```
    \+ added
    ```cpp
    libretro_supports_option_categories = false;
    ```
    in retro_deinit().

Categories names/descriptions are pretty basic atm, it could be changed later of course. I also changed "Patches: Enable Cheats" to "Emulation: Enable Cheats" so it's not alone in its own category.

Pretty big changes and I never updated core options version before, so I'd really like a review! I really hope I did everything properly, from my tests it seems to work fine (on Windows at least, unfortunately the core doesn't run on my Linux VM), I don't think I broke anything :D 