### PR TITLE
Add "Fast Texture Invalidation" hack core option

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -909,6 +909,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      BOOL_PCSX2_OPT_USERHACK_FAST_INVALIDATION,
+      "Hack: Fast Texture Invalidation",
+      "Fast Texture Invalidation",
+      "By default, the texture cache handles partial invalidations. Unfortunately it is very costly to compure CPU wise. \
+      \nThis hack replaces the partial invalidation with a complete deletion of the texture to reduce the CPU load. (Content restart required)",
+      NULL,
+      "hacks_options",
+      {
+         {"disabled", NULL},
+         {"enabled", NULL},
+         {NULL, NULL},
+      },
+      "disabled"
+   },
+   {
       BOOL_PCSX2_OPT_USERHACK_FB_CONVERSION,
       "Hack: Frame Buffer Conversion",
       "Frame Buffer Conversion",

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -60,6 +60,7 @@ int option_pad_left_deadzone = 0;
 int option_pad_right_deadzone = 0;
 bool hack_fb_conversion = false;
 bool hack_AutoFlush = false;
+bool hack_fast_invalidation = false;
 
 std::string sel_bios_path = "";
 retro_environment_t environ_cb;
@@ -315,6 +316,7 @@ void retro_init(void)
 	option_upscale_mult = option_value(INT_PCSX2_OPT_UPSCALE_MULTIPLIER, KeyOptionInt::return_type);
 	hack_fb_conversion = option_value(BOOL_PCSX2_OPT_USERHACK_FB_CONVERSION, KeyOptionBool::return_type);
 	hack_AutoFlush = option_value(BOOL_PCSX2_OPT_USERHACK_AUTO_FLUSH, KeyOptionBool::return_type);
+	hack_fast_invalidation = option_value(BOOL_PCSX2_OPT_USERHACK_FAST_INVALIDATION, KeyOptionBool::return_type);
 
 	wxFileName f_bios;
 	f_bios.Assign(option_value(STRING_PCSX2_OPT_BIOS, KeyOptionString::return_type));

--- a/libretro/options_enums.h
+++ b/libretro/options_enums.h
@@ -16,6 +16,7 @@
 #define BOOL_PCSX2_OPT_USERHACK_AUTO_FLUSH	 "pcsx2_userhack_auto_flush"
 #define BOOL_PCSX2_OPT_CONSERVATIVE_BUFFER	 "pcsx2_conservative_buffer"
 #define BOOL_PCSX2_OPT_ACCURATE_DATE		 "pcsx2_accurate_date"
+#define BOOL_PCSX2_OPT_USERHACK_FAST_INVALIDATION      "pcsx2_fast_invalidation"
 
 #define STRING_PCSX2_OPT_BIOS			 "pcsx2_bios"
 #define STRING_PCSX2_OPT_RENDERER                "pcsx2_renderer"

--- a/libretro/options_tools.h
+++ b/libretro/options_tools.h
@@ -12,6 +12,7 @@ extern int option_pad_left_deadzone;
 extern int option_pad_right_deadzone;
 extern bool hack_fb_conversion;
 extern bool hack_AutoFlush;
+extern bool hack_fast_invalidation;
 /*
 * These are quick fixes to provide system paths at pcsx2 app startup.
 * Because of the huge refactoring, paths are not saved/loaded from inis files anymore,

--- a/plugins/GS/Renderers/HW/GSTextureCache.cpp
+++ b/plugins/GS/Renderers/HW/GSTextureCache.cpp
@@ -37,7 +37,7 @@ GSTextureCache::GSTextureCache(GSRenderer* r)
 
 	UserHacks_HalfPixelOffset      = false;
 	m_preload_frame                = false;
-	m_disable_partial_invalidation = false;
+	m_disable_partial_invalidation = hack_fast_invalidation;
 	m_can_convert_depth            = true;
 	m_cpu_fb_conversion            = hack_fb_conversion;
 	m_texture_inside_rt            = false;


### PR DESCRIPTION
Helps a lot in some games, here's a few examples with 2 Silent Hill games:

**Silent Hill - Shattered Memories** (textures are a complete mess, the doctor in the intro is invisible, etc.):

Fast Texture Invalidation OFF | Fast Texture Invalidation ON
---|---
![sh1-off](https://user-images.githubusercontent.com/33353403/144728084-3eb326d3-03dc-4310-ace4-d12a92923cc0.png) | ![sh1-on](https://user-images.githubusercontent.com/33353403/144728088-1d102ead-3126-4a70-9962-3cd00684f45b.png)
![sh2-off](https://user-images.githubusercontent.com/33353403/144728096-d2e99605-f04a-496c-8e05-657f137eb335.png) | ![sh2-on](https://user-images.githubusercontent.com/33353403/144728097-373ed3a1-9dd3-44d1-8a99-e6190b1f9f2a.png)

**Silent Hill Origins** (weird texture glitches as well, flashlight effects completely broken, etc.):

Fast Texture Invalidation OFF | Fast Texture Invalidation ON
---|---
![sh3-off](https://user-images.githubusercontent.com/33353403/144728119-a267de2b-a5ee-4433-a8ea-edc0be14f9cb.png) | ![sh3-on](https://user-images.githubusercontent.com/33353403/144728121-93994dfa-03a8-4c06-b80e-e69e8bdcd436.png)
![sh4-off](https://user-images.githubusercontent.com/33353403/144728123-180ac6e3-e6da-43ed-aa59-c0d722b3aff9.png) | ![sh4-on](https://user-images.githubusercontent.com/33353403/144728125-0256503e-7a63-4a8e-8be3-4358bb7c0891.png)

Again I'd appreciate a review before merging, I'm sorry I must be annoying with that but I really don't want to break anything 😓 As you can see from the screenshots, it worked fine during my tests.

If everything is OK, this closes #186