### PR TITLE
Tweaks to the "Auto" renderer

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -828,10 +828,20 @@ bool retro_load_game(const struct retro_game_info* game)
 
 	retro_hw_context_type context_type = RETRO_HW_CONTEXT_OPENGL;
 	const char* option_renderer = option_value(STRING_PCSX2_OPT_RENDERER, KeyOptionString::return_type);
-	log_cb(RETRO_LOG_INFO, "options renderer: %s\n", option_renderer);
+	log_cb(RETRO_LOG_INFO, "Renderer option set to: %s\n", option_renderer);
 
-	if (! std::strcmp(option_renderer,"Auto"))
+	if (!std::strcmp(option_renderer,"Auto"))
+	{
 		environ_cb(RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER, &context_type);
+		// Check if the selected video driver is supported, switch to OpenGL otherwise.
+		if (context_type != RETRO_HW_CONTEXT_NONE && set_hw_render(context_type))
+			return true;
+		else
+		{
+			context_type = RETRO_HW_CONTEXT_OPENGL;
+			log_cb(RETRO_LOG_INFO, "The video driver found is not compatible, switched to OpenGL.\n");
+		}
+	}
 #ifdef _WIN32
 	else if (!std::strcmp(option_renderer, "D3D11"))
 		context_type = RETRO_HW_CONTEXT_DIRECT3D;


### PR DESCRIPTION
When "Auto" renderer is selected, if the frontend video driver isn't set to GL or D3D then it will default to GL instead of just failing to load.

Closes #13