### PR TITLE
Fix Applying Settings on-the-fly

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -883,7 +883,7 @@ void retro_run(void)
 		EmuConfig.GS.FramesToDraw = option_value(INT_PCSX2_OPT_FRAMES_TO_DRAW, KeyOptionInt::return_type);
 		EmuConfig.GS.FramesToSkip = option_value(INT_PCSX2_OPT_FRAMES_TO_SKIP, KeyOptionInt::return_type);
 		EmuConfig.GS.VsyncQueueSize = option_value(INT_PCSX2_OPT_VSYNC_MTGS_QUEUE, KeyOptionInt::return_type);
-		//GSUpdateOptions();
+		GSUpdateOptions();
 		Input::RumbleEnabled(
 			option_value(BOOL_PCSX2_OPT_GAMEPAD_RUMBLE_ENABLE, KeyOptionBool::return_type),
 			option_value(INT_PCSX2_OPT_GAMEPAD_RUMBLE_FORCE, KeyOptionInt::return_type)


### PR DESCRIPTION
This commit allows PCSX2 to apply resolution changes without needing to restart RetroArch for it to take effect once again.
![notepad++_L8Ye8p4J7c](https://user-images.githubusercontent.com/48205338/172027509-063e906b-801b-4031-8048-230f472c9580.png)

