### PR TITLE
VU int

### DIFF
--- a/pcsx2/Gif_Unit.h
+++ b/pcsx2/Gif_Unit.h
@@ -536,6 +536,8 @@ struct Gif_Unit
 				return 0; // Bios does this... (Fixed if you delay vu1's xgkick by 103 vu cycles)
 			if (curSize >= size)
 				return size;
+			if(!EmuConfig.Cpu.Recompiler.EnableVU1 && pathIdx == GIF_PATH_1)
+				return curSize | ((u32)gifTag.tag.EOP << 31);
 			if (gifTag.tag.EOP)
 				return curSize;
 		}

--- a/pcsx2/VU.h
+++ b/pcsx2/VU.h
@@ -101,6 +101,7 @@ struct efuPipe {
 struct fmacPipe {
 	int enable;
 	int reg;
+	int flagreg;
 	int xyzw;
 	u32 sCycle;
 	u32 Cycle;
@@ -160,6 +161,12 @@ struct __aligned16 VURegs {
 	u8 *Mem;
 	u8 *Micro;
 
+	u32 xgkickenable;
+	u32 xgkickaddr;
+	u32 xgkickdiff;
+	u32 xgkicksizeremaining;
+	u32 xgkicklastcycle;
+	u32 xgkickendpacket;
 	u32 ebit;
 
 	u8 VIBackupCycles;

--- a/pcsx2/VU0.cpp
+++ b/pcsx2/VU0.cpp
@@ -64,7 +64,7 @@ __fi void _vu0run(bool breakOnMbit, bool addCycles) {
 		return;
 	}
 
-	u32 startcycle = VU0.cycle;
+	u32 startcycle = cpuRegs.cycle;
 	u32 runCycles  = 0x7fffffff;
 
 	do { // Run VU until it finishes or M-Bit
@@ -76,7 +76,6 @@ __fi void _vu0run(bool breakOnMbit, bool addCycles) {
 	if (addCycles)
 	{
 		cpuRegs.cycle += (VU0.cycle - startcycle);
-		VU0.cycle = cpuRegs.cycle;
 	}
 }
 

--- a/pcsx2/VU0micro.cpp
+++ b/pcsx2/VU0micro.cpp
@@ -41,7 +41,9 @@ void __fastcall vu0ExecMicro(u32 addr)
 		vu0Finish();
 
 	// Need to copy the clip flag back to the interpreter in case COP2 has edited it
-	VU0.clipflag = VU0.VI[REG_CLIP_FLAG].UL;
+	VU0.clipflag   = VU0.VI[REG_CLIP_FLAG].UL;
+	VU0.macflag    = VU0.VI[REG_MAC_FLAG].UL;
+	VU0.statusflag = VU0.VI[REG_STATUS_FLAG].UL;
 	VU0.VI[REG_VPU_STAT].UL &= ~0xFF;
 	VU0.VI[REG_VPU_STAT].UL |=  0x01;
 	VU0.cycle = cpuRegs.cycle;

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -19,6 +19,8 @@
 
 #include "VUmicro.h"
 
+#include <cfenv>
+
 extern void _vuFlushAll(VURegs* VU);
 
 static void _vu0ExecUpper(VURegs* VU, u32 *ptr)
@@ -76,6 +78,7 @@ static void _vu0Exec(VURegs* VU)
 
 	/* check upper flags */
 	if (ptr[1] & 0x80000000) { /* I flag */
+		_vuTestPipes(VU);
 		_vu0ExecUpper(VU, ptr);
 
 		VU->VI[REG_I].UL = ptr[0];
@@ -87,6 +90,7 @@ static void _vu0Exec(VURegs* VU)
 		_vuTestLowerStalls(VU, &lregs);
 #endif
 
+		_vuTestPipes(VU);
 		vfreg = 0;
 		vireg = 0;
 		if (uregs.VFwrite) {
@@ -132,8 +136,6 @@ static void _vu0Exec(VURegs* VU)
 	if (!(ptr[1] & 0x80000000))
 		_vuAddLowerStalls(VU, &lregs);
 
-	_vuTestPipes(VU);
-
 	if(VU->VIBackupCycles > 0) 
 		VU->VIBackupCycles--;
 
@@ -164,8 +166,8 @@ static void _vu0Exec(VURegs* VU)
 static void vu0Exec(VURegs* VU)
 {
 	VU0.VI[REG_TPC].UL &= VU0_PROGMASK;
-	_vu0Exec(VU);
 	VU->cycle++;
+	_vu0Exec(VU);
 }
 
 // --------------------------------------------------------------------------------------
@@ -183,6 +185,9 @@ void InterpVU0::SetStartPC(u32 startPC)
 
 void InterpVU0::Execute(u32 cycles)
 {
+	const int originalRounding = fegetround();
+	fesetround(g_sseVUMXCSR.RoundingControl << 8);
+
 	VU0.VI[REG_TPC].UL <<= 3;
 	VU0.flags &= ~VUFLAG_MFLAGSET;
 	for (int i = (int)cycles; i > 0; i--) {
@@ -194,4 +199,6 @@ void InterpVU0::Execute(u32 cycles)
 		vu0Exec(&VU0);
 	}
 	VU0.VI[REG_TPC].UL >>= 3;
+
+	fesetround(originalRounding);
 }

--- a/pcsx2/VU0microInterp.cpp
+++ b/pcsx2/VU0microInterp.cpp
@@ -140,9 +140,7 @@ static void _vu0Exec(VURegs* VU)
 		}
 	}
 	_vuAddUpperStalls(VU, &uregs);
-
-	if (!(ptr[1] & 0x80000000))
-		_vuAddLowerStalls(VU, &lregs);
+	_vuAddLowerStalls(VU, &lregs);
 
 	if (VU->branch > 0) {
 		if (VU->branch-- == 1) {
@@ -195,7 +193,8 @@ void InterpVU0::Execute(u32 cycles)
 
 	VU0.VI[REG_TPC].UL <<= 3;
 	VU0.flags &= ~VUFLAG_MFLAGSET;
-	for (int i = (int)cycles; i > 0; i--) {
+	u32 startcycles = VU0.cycle;
+	while((VU0.cycle - startcycles) < cycles) {
 		if (!(VU0.VI[REG_VPU_STAT].UL & 0x1) || (VU0.flags & VUFLAG_MFLAGSET)) {
 			if (VU0.branch || VU0.ebit)
 				vu0Exec(&VU0); // run branch delay slot?

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -18,7 +18,11 @@
 #include "Common.h"
 
 #include "VUmicro.h"
+#include "GS.h"
+#include "Gif_Unit.h"
 #include "MTVU.h"
+
+#include <cfenv>
 
 extern void _vuFlushAll(VURegs* VU);
 
@@ -50,59 +54,66 @@ static void _vu1Exec(VURegs* VU)
 
 	if (ptr[1] & 0x40000000) /* E flag */
 		VU->ebit = 2;
-	if (ptr[1] & 0x10000000) { /* D flag */
-		if (VU0.VI[REG_FBRST].UL & 0x400) {
+	if (ptr[1] & 0x10000000) /* D flag */
+	{ 
+		if (VU0.VI[REG_FBRST].UL & 0x400)
+		{
 			VU0.VI[REG_VPU_STAT].UL|= 0x200;
 			hwIntcIrq(INTC_VU1);
 			VU->ebit = 1;
 		}
-		
 	}
-	if (ptr[1] & 0x08000000) { /* T flag */
-		if (VU0.VI[REG_FBRST].UL & 0x800) {
+	if (ptr[1] & 0x08000000) /* T flag */
+	{
+		if (VU0.VI[REG_FBRST].UL & 0x800)
+		{
 			VU0.VI[REG_VPU_STAT].UL|= 0x400;
 			hwIntcIrq(INTC_VU1);
 			VU->ebit = 1;
 		}
-		
 	}
 
 	VU->code = ptr[1];
 	VU1regs_UPPER_OPCODE[VU->code & 0x3f](&uregs);
-#ifndef INT_VUSTALLHACK
 	_vuTestUpperStalls(VU, &uregs);
-#endif
 
 	/* check upper flags */
-	if (ptr[1] & 0x80000000) { /* I flag */
+	if (ptr[1] & 0x80000000) /* I flag */
+	{
+		_vuTestPipes(VU);
 		_vu1ExecUpper(VU, ptr);
 
 		VU->VI[REG_I].UL = ptr[0];
 		//Lower not used, set to 0 to fill in the FMAC stall gap
 		//Could probably get away with just running upper stalls, but lets not tempt fate.
 		memset(&lregs, 0, sizeof(lregs));		
-	} else {
+	}
+	else
+	{
 		VU->code = ptr[0];
 		VU1regs_LOWER_OPCODE[VU->code >> 25](&lregs);
-#ifndef INT_VUSTALLHACK
 		_vuTestLowerStalls(VU, &lregs);
-#endif
+		_vuTestPipes(VU);
 
 		vfreg = 0;
 		vireg = 0;
-		if (uregs.VFwrite) {
+		if (uregs.VFwrite)
+		{
 			if (lregs.VFwrite == uregs.VFwrite)
 				discard = 1;
-			if (lregs.VFread0 == uregs.VFwrite ||
-				lregs.VFread1 == uregs.VFwrite) {
+			if (   lregs.VFread0 == uregs.VFwrite 
+			    || lregs.VFread1 == uregs.VFwrite)
+			{
 				_VF = VU->VF[uregs.VFwrite];
 				vfreg = uregs.VFwrite;
 			}
 		}
-		if (uregs.VIread & (1 << REG_CLIP_FLAG)) {
+		if (uregs.VIwrite & (1 << REG_CLIP_FLAG))
+		{
 			if (lregs.VIwrite & (1 << REG_CLIP_FLAG))
 				discard = 1;
-			if (lregs.VIread & (1 << REG_CLIP_FLAG)) {
+			if (lregs.VIread & (1 << REG_CLIP_FLAG))
+			{
 				_VI = VU->VI[REG_CLIP_FLAG];
 				vireg = REG_CLIP_FLAG;
 			}
@@ -110,39 +121,40 @@ static void _vu1Exec(VURegs* VU)
 
 		_vu1ExecUpper(VU, ptr);
 
-		if (discard == 0) {
-			if (vfreg) {
+		if (discard == 0)
+		{
+			if (vfreg)
+			{
 				_VFc = VU->VF[vfreg];
 				VU->VF[vfreg] = _VF;
 			}
-			if (vireg) {
+			if (vireg)
+			{
 				_VIc = VU->VI[vireg];
 				VU->VI[vireg] = _VI;
 			}
 
 			_vu1ExecLower(VU, ptr);
 
-			if (vfreg) {
+			if (vfreg)
 				VU->VF[vfreg] = _VFc;
-			}
-			if (vireg) {
+			if (vireg)
 				VU->VI[vireg] = _VIc;
-			}
 		}
 	}
 	_vuAddUpperStalls(VU, &uregs);
 	_vuAddLowerStalls(VU, &lregs);
 
-	_vuTestPipes(VU);
-	
 	if(VU->VIBackupCycles > 0) 
 		VU->VIBackupCycles--;
 	
-	if (VU->branch > 0) {
-		if (VU->branch-- == 1) {
+	if (VU->branch > 0)
+	{
+		if (VU->branch-- == 1)
+		{
 			VU->VI[REG_TPC].UL = VU->branchpc;
 
-			if(VU->takedelaybranch)
+			if (VU->takedelaybranch)
 			{				
 				VU->branch          = 1;
 				VU->branchpc        = VU->delaybranchpc;
@@ -152,20 +164,51 @@ static void _vu1Exec(VURegs* VU)
 		}
 	}
 
-	if( VU->ebit > 0 ) {
-		if( VU->ebit-- == 1 ) {
+	if( VU->ebit > 0 )
+	{
+		if( VU->ebit-- == 1 )
+		{
 			VU->VIBackupCycles = 0;
 			_vuFlushAll(VU);
 			VU0.VI[REG_VPU_STAT].UL &= ~0x100;
 			vif1Regs.stat.VEW = false;
 		}
 	}
+	if (VU->xgkickenable && (VU1.cycle - VU->xgkicklastcycle) >= 2)
+	{
+		if (VU->xgkicksizeremaining == 0)
+		{
+			u32 size = gifUnit.GetGSPacketSize(GIF_PATH_1, VU->Mem, VU->xgkickaddr);
+			VU->xgkicksizeremaining = size & 0xFFFF;
+			VU->xgkickendpacket = size >> 31;
+			if (VU->xgkicksizeremaining == 0)
+				VU->xgkickenable = 0;
+		}
+		u32 transfersize = std::min(VU->xgkicksizeremaining / 0x10, (VU1.cycle - VU->xgkicklastcycle) / 2);
+		if (transfersize)
+		{
+			if ((transfersize * 0x10) > VU->xgkicksizeremaining)
+				gifUnit.gifPath[GIF_PATH_1].CopyGSPacketData(&VU->Mem[VU->xgkickaddr], transfersize * 0x10, true);
+			else
+				gifUnit.TransferGSPacketData(GIF_TRANS_XGKICK, &VU->Mem[VU->xgkickaddr], transfersize * 0x10, true);
+
+			VU->xgkickaddr = (VU->xgkickaddr + (transfersize * 0x10)) & 0x3FFF;
+			VU->xgkicksizeremaining -= (transfersize * 0x10);
+			VU->xgkickdiff = 0x4000 - VU->xgkickaddr;
+			VU->xgkicklastcycle += std::max(transfersize * 2, 2U);
+
+			if (VU->xgkicksizeremaining || !VU->xgkickendpacket)
+				VU->xgkickenable = 1;
+			else
+				VU->xgkickenable = 0;
+		}
+	}
 }
 
 static void vu1Exec(VURegs* VU)
 {
-	_vu1Exec(VU);
 	VU->cycle++;
+	_vu1Exec(VU);
 }
 
 InterpVU1::InterpVU1()
@@ -173,11 +216,13 @@ InterpVU1::InterpVU1()
 	m_Idx = 1;
 }
 
-void InterpVU1::Reset() {
+void InterpVU1::Reset()
+{
 	vu1Thread.WaitVU();
 }
 
-void InterpVU1::Shutdown() noexcept {
+void InterpVU1::Shutdown() noexcept
+{
 	vu1Thread.WaitVU();
 }
 
@@ -188,8 +233,12 @@ void InterpVU1::SetStartPC(u32 startPC)
 
 void InterpVU1::Execute(u32 cycles)
 {
+	const int originalRounding = fegetround();
+	fesetround(g_sseVUMXCSR.RoundingControl << 8);
+
 	VU1.VI[REG_TPC].UL <<= 3;
-	for (int i = (int)cycles; i > 0; i--) {
+	for (int i = (int)cycles; i > 0; i--)
+	{
 		if (!(VU0.VI[REG_VPU_STAT].UL & 0x100))
 		{
 			/* run branch delay slot? */
@@ -201,8 +250,10 @@ void InterpVU1::Execute(u32 cycles)
 			break;
 		}
 		VU1.VI[REG_TPC].UL &= VU1_PROGMASK;
-		vu1Exec( &VU1 );
+		vu1Exec(&VU1);
 	}
 	VU1.VI[REG_TPC].UL >>= 3;
+
+	fesetround(originalRounding);
 }
 

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -185,6 +185,8 @@ static void _vu1Exec(VURegs* VU)
 				VU->xgkickenable = 0;
 		}
 		u32 transfersize = std::min(VU->xgkicksizeremaining / 0x10, (VU1.cycle - VU->xgkicklastcycle) / 2);
+		transfersize = std::min(transfersize, VU->xgkickdiff / 0x10);
+
 		if (transfersize)
 		{
 			if ((transfersize * 0x10) > VU->xgkicksizeremaining)

--- a/pcsx2/VU1microInterp.cpp
+++ b/pcsx2/VU1microInterp.cpp
@@ -245,7 +245,8 @@ void InterpVU1::Execute(u32 cycles)
 	fesetround(g_sseVUMXCSR.RoundingControl << 8);
 
 	VU1.VI[REG_TPC].UL <<= 3;
-	for (int i = (int)cycles; i > 0; i--)
+	u32 startcycles = VU1.cycle;
+	while ((VU1.cycle - startcycles) < cycles)
 	{
 		if (!(VU0.VI[REG_VPU_STAT].UL & 0x100))
 		{

--- a/pcsx2/VUflags.cpp
+++ b/pcsx2/VUflags.cpp
@@ -102,5 +102,5 @@ __ri void VU_STAT_UPDATE(VURegs * VU)
 	if (VU->macflag & 0x0F00) newflag |= 0x4;
 	if (VU->macflag & 0xF000) newflag |= 0x8;
 	// Save old sticky flags and D/I settings, everthing else is the new flags only
-	VU->statusflag = (VU->statusflag&0xff0)| newflag | (newflag<<6);
+	VU->statusflag = newflag;
 }

--- a/pcsx2/VUflags.cpp
+++ b/pcsx2/VUflags.cpp
@@ -43,7 +43,7 @@ static __ri u32 VU_MAC_UPDATE( int shift, VURegs * VU, float f )
 				VU->macflag = (VU->macflag&~(0x1000<<shift)) | (0x0101<<shift);
 				return s;
 			case 255:
-				VU->macflag = (VU->macflag&~(0x0100<<shift)) | (0x1000<<shift);
+				VU->macflag = (VU->macflag&~(0x0101<<shift)) | (0x1000<<shift);
 				return s|0x7f7fffff; /* max allowed */
 			default:
 				VU->macflag = (VU->macflag & ~(0x1101<<shift));
@@ -101,5 +101,6 @@ __ri void VU_STAT_UPDATE(VURegs * VU)
 	if (VU->macflag & 0x00F0) newflag |= 0x2;
 	if (VU->macflag & 0x0F00) newflag |= 0x4;
 	if (VU->macflag & 0xF000) newflag |= 0x8;
-	VU->statusflag = (VU->statusflag&0xc30)|newflag|((VU->statusflag&0xf)<<6);
+	// Save old sticky flags and D/I settings, everthing else is the new flags only
+	VU->statusflag = (VU->statusflag&0xff0)| newflag | (newflag<<6);
 }

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -43,6 +43,8 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp) {
 					VU1.xgkickendpacket = size >> 31;
 				}
 				u32 transfersize = std::min(VU1.xgkicksizeremaining / 0x10, (cpuRegs.cycle - VU1.xgkicklastcycle) / 2);
+				transfersize = std::min(transfersize, VU1.xgkickdiff / 0x10);
+
 				if (transfersize)
 				{
 					if ((transfersize * 0x10) > VU1.xgkicksizeremaining)

--- a/pcsx2/VUmicro.cpp
+++ b/pcsx2/VUmicro.cpp
@@ -20,6 +20,7 @@
 #include "MTVU.h"
 
 // Executes a Block based on EE delta time
+#if 1
 void BaseVUmicroCPU::ExecuteBlock(bool startUp) {
 	const u32& stat	= VU0.VI[REG_VPU_STAT].UL;
 	const int  test = m_Idx ? 0x100 : 1;
@@ -81,6 +82,68 @@ void BaseVUmicroCPU::ExecuteBlock(bool startUp) {
 			Execute(delta);	// Execute the time since the last call
 	}
 }
+#else
+/* Should work correctly with Crash Twinsanity? */
+void BaseVUmicroCPU::ExecuteBlock(bool startUp)
+{
+	const u32& stat = VU0.VI[REG_VPU_STAT].UL;
+	const int test = m_Idx ? 0x100 : 1;
+	const int s = EmuConfig.Gamefixes.VUKickstartHack ? 16 : 0; // Kick Start Cycles (Jak needs at least 4 due to writing values after they're read
+
+	if (m_Idx && THREAD_VU1)
+	{
+		vu1Thread.Get_GSChanges();
+		return;
+	}
+
+	if (!(stat & test))
+		return;
+
+	if (startUp && s) // Start Executing a microprogram (When kickstarted)
+	{
+		Execute(s); // Kick start VU
+
+		// I don't like doing this, but Crash Twinsanity seems to be upset without it
+		if (stat & test)
+		{
+			if (m_Idx)
+			        cpuRegs.cycle = VU1.cycle;
+			else
+				cpuRegs.cycle = VU0.cycle;
+
+			cpuSetNextEventDelta(s);
+		}
+	}
+	else // Continue Executing
+	{
+		u32 cycle = m_Idx ? VU1.cycle : VU0.cycle;
+		s32 delta = (s32)(u32)(cpuRegs.cycle - cycle);
+		s32 nextblockcycles = m_Idx ? VU1.nextBlockCycles : VU0.nextBlockCycles;
+
+		if (EmuConfig.Gamefixes.VUKickstartHack)
+		{
+			if (delta > 0)  // When kickstarting we just need 1 cycle for run ahead
+			Execute(delta);
+		}
+		else
+		{
+			if (delta >= nextblockcycles) // When running behind, make sure we have enough cycles passed for the block to run
+				Execute(delta);
+		}
+
+		if (stat & test)
+		{
+			// Queue up next required time to run a block
+			nextblockcycles = m_Idx ? VU1.nextBlockCycles : VU0.nextBlockCycles;
+			cycle           = m_Idx ? VU1.cycle : VU0.cycle;
+			nextblockcycles = EmuConfig.Gamefixes.VUKickstartHack ? (cycle - cpuRegs.cycle) : nextblockcycles;
+
+			if(nextblockcycles)
+				cpuSetNextEventDelta(nextblockcycles);
+		}
+	}
+}
+#endif
 
 // This function is called by VU0 Macro (COP2) after transferring some
 // EE data to VU0's registers. We want to run VU0 Micro right after this

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -1437,40 +1437,49 @@ static __fi void _vuOPMSUB(VURegs * VU) {
 static __fi void _vuNOP(VURegs * VU) {
 }
 
+static __fi s32 float_to_int(float value)
+{
+	if (value >= 2147483647.0)
+		return 2147483647LL;
+	if (value <= -2147483648.0)
+		return -2147483648LL;
+	return value;
+}
+
 static __fi void _vuFTOI0(VURegs * VU) {
 	if (_Ft_ == 0) return;
 
-	if (_X) VU->VF[_Ft_].SL[0] = (s32)vuDouble(VU->VF[_Fs_].i.x);
-	if (_Y) VU->VF[_Ft_].SL[1] = (s32)vuDouble(VU->VF[_Fs_].i.y);
-	if (_Z) VU->VF[_Ft_].SL[2] = (s32)vuDouble(VU->VF[_Fs_].i.z);
-	if (_W) VU->VF[_Ft_].SL[3] = (s32)vuDouble(VU->VF[_Fs_].i.w);
+	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(vuDouble(VU->VF[_Fs_].i.x));
+	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(vuDouble(VU->VF[_Fs_].i.y));
+	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int(vuDouble(VU->VF[_Fs_].i.z));
+	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(vuDouble(VU->VF[_Fs_].i.w));
 }
 
 static __fi void _vuFTOI4(VURegs * VU) {
 	if (_Ft_ == 0) return;
 
-	if (_X) VU->VF[_Ft_].SL[0] = float_to_int4(vuDouble(VU->VF[_Fs_].i.x));
-	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int4(vuDouble(VU->VF[_Fs_].i.y));
-	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int4(vuDouble(VU->VF[_Fs_].i.z));
-	if (_W) VU->VF[_Ft_].SL[3] = float_to_int4(vuDouble(VU->VF[_Fs_].i.w));
+	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.x)));
+	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.y)));
+	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.z)));
+	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(float_to_int4(vuDouble(VU->VF[_Fs_].i.w)));
 }
 
 static __fi void _vuFTOI12(VURegs * VU) {
 	if (_Ft_ == 0) return;
 
-	if (_X) VU->VF[_Ft_].SL[0] = float_to_int12(vuDouble(VU->VF[_Fs_].i.x));
-	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int12(vuDouble(VU->VF[_Fs_].i.y));
-	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int12(vuDouble(VU->VF[_Fs_].i.z));
-	if (_W) VU->VF[_Ft_].SL[3] = float_to_int12(vuDouble(VU->VF[_Fs_].i.w));
+	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.x)));
+	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.y)));
+	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.z)));
+	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(float_to_int12(vuDouble(VU->VF[_Fs_].i.w)));
 }
 
 static __fi void _vuFTOI15(VURegs * VU) {
 	if (_Ft_ == 0) return;
 
-	if (_X) VU->VF[_Ft_].SL[0] = float_to_int15(vuDouble(VU->VF[_Fs_].i.x));
-	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int15(vuDouble(VU->VF[_Fs_].i.y));
-	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int15(vuDouble(VU->VF[_Fs_].i.z));
-	if (_W) VU->VF[_Ft_].SL[3] = float_to_int15(vuDouble(VU->VF[_Fs_].i.w));
+	if (_X) VU->VF[_Ft_].SL[0] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.x)));
+	if (_Y) VU->VF[_Ft_].SL[1] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.y)));
+	if (_Z) VU->VF[_Ft_].SL[2] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.z)));
+	if (_W) VU->VF[_Ft_].SL[3] = float_to_int(float_to_int15(vuDouble(VU->VF[_Fs_].i.w)));
 }
 
 static __fi void _vuITOF0(VURegs * VU) {

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -78,20 +78,17 @@ static __ri bool _vuFMACflush(VURegs * VU) {
 
 			VU->fmac[currentpipe].enable = 0;
 
-			if ((VU->fmac[currentpipe].sCycle + VU->fmac[currentpipe].Cycle) >= cycle)
+			if (VU->fmac[currentpipe].flagreg & (1 << REG_STATUS_FLAG))
+				VU->VI[REG_STATUS_FLAG].UL = (VU->VI[REG_STATUS_FLAG].UL & 0x3F) | (VU->fmac[currentpipe].statusflag & 0xFC0);
+			else if (VU->fmac[currentpipe].flagreg & (1 << REG_CLIP_FLAG))
+				VU->VI[REG_CLIP_FLAG].UL = VU->fmac[currentpipe].clipflag;
+			else
 			{
-				if (VU->fmac[currentpipe].flagreg & (1 << REG_STATUS_FLAG))
-					VU->VI[REG_STATUS_FLAG].UL = (VU->VI[REG_STATUS_FLAG].UL & 0x3F) | (VU->fmac[currentpipe].statusflag & 0xFC0);
-				else if (VU->fmac[currentpipe].flagreg & (1 << REG_CLIP_FLAG))
-					VU->VI[REG_CLIP_FLAG].UL = VU->fmac[currentpipe].clipflag;
-				else
-				{
-					// FMAC only affectx Z/S/I/O
-					VU->VI[REG_STATUS_FLAG].UL = (VU->VI[REG_STATUS_FLAG].UL & 0xFF0) | (VU->fmac[currentpipe].statusflag & 0x3CF);
-					VU->VI[REG_MAC_FLAG].UL = VU->fmac[currentpipe].macflag;
-
-				}
+				// FMAC only affectx Z/S/I/O
+				VU->VI[REG_STATUS_FLAG].UL = (VU->VI[REG_STATUS_FLAG].UL & 0xFF0) | (VU->fmac[currentpipe].statusflag & 0x3CF);
+				VU->VI[REG_MAC_FLAG].UL = VU->fmac[currentpipe].macflag;
 			}
+
 			didflush = true;
 		}
 	}
@@ -2137,8 +2134,7 @@ static __ri void _vuERLENG(VURegs * VU)
 	float p = vuDouble(VU->VF[_Fs_].i.x) * vuDouble(VU->VF[_Fs_].i.x) + vuDouble(VU->VF[_Fs_].i.y) * vuDouble(VU->VF[_Fs_].i.y) + vuDouble(VU->VF[_Fs_].i.z) * vuDouble(VU->VF[_Fs_].i.z);
 	if (p >= 0)
 	{
-		p = sqrt(p);
-		if (p != 0)
+		if ((p = sqrt(p)) != 0)
 			p = 1.0f / p;
 	}
 	VU->p.F = p;

--- a/pcsx2/VUops.cpp
+++ b/pcsx2/VUops.cpp
@@ -250,7 +250,6 @@ void _vuFlushAll(VURegs* VU)
 
 __fi void _vuTestPipes(VURegs * VU) {
 	bool flushed;
-	u32 startcycle = VU->cycle;
 	do {
 		flushed = false;
 		flushed |= _vuFMACflush(VU);

--- a/pcsx2/VUops.h
+++ b/pcsx2/VUops.h
@@ -17,9 +17,9 @@
 #include "VU.h"
 #include "VUflags.h"
 
-#define float_to_int4(x)	(s32)((float)x * (1.0f / 0.0625f))
-#define float_to_int12(x)	(s32)((float)x * (1.0f / 0.000244140625f))
-#define float_to_int15(x)	(s32)((float)x * (1.0f / 0.000030517578125))
+#define float_to_int4(x)	((float)x * (1.0f / 0.0625f))
+#define float_to_int12(x)	((float)x * (1.0f / 0.000244140625f))
+#define float_to_int15(x)	((float)x * (1.0f / 0.000030517578125))
 
 #define int4_to_float(x)	(float)((float)x * 0.0625f)
 #define int12_to_float(x)	(float)((float)x * 0.000244140625f)


### PR DESCRIPTION
Backport of PCSX2 PR. Only liberties here taken are the codepath where we diverge from upstream because doing it the upstream way would lose us valuable performance (as a tradeoff for Crash Twinsanity working correctly). The #else block in #if 1 (ExecuteBlock) should theoretically make Crash Twinsanity work correctly again, but has to be studied further.