### PR TITLE
Remove System > PCSX2 > BIOS folder requirement.

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -965,5 +965,6 @@ wxString GetExecutablePath()
 {
 	const char* system = nullptr;
 	environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system);
-	return Path::Combine(system);
+	return (system);
+	//return Path::Combine(system, "pcsx2/PCSX2");
 }

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -264,7 +264,7 @@ void retro_init(void)
 
 	// get the BIOS available and fill the option
 
-	bios_dir = Path::Combine(system, "pcsx2/bios");
+	bios_dir = Path::Combine(system);
 
 	wxArrayString bios_list;
 	wxDir::GetAllFiles(bios_dir.GetFullPath(), &bios_list, L"*.*", wxDIR_FILES);
@@ -965,5 +965,5 @@ wxString GetExecutablePath()
 {
 	const char* system = nullptr;
 	environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system);
-	return Path::Combine(system, "pcsx2/PCSX2");
+	return Path::Combine(system);
 }

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -264,7 +264,7 @@ void retro_init(void)
 
 	// get the BIOS available and fill the option
 
-	bios_dir = Path::Combine(system);
+	bios_dir = (system);
 
 	wxArrayString bios_list;
 	wxDir::GetAllFiles(bios_dir.GetFullPath(), &bios_list, L"*.*", wxDIR_FILES);


### PR DESCRIPTION
This PR makes it so that users can simply place their PS2 BIOS .bin files in the system folder.

Too many users find the setup for this core difficult, and require help getting the system > pcsx2 > bios folder to work. This PR makes PCSX2 fall more in line with other PlayStation cores which load their BIOS files directly from the system folder.

 