### PR TITLE
Remove system > pcsx2 > bios requirement

### DIFF
--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -965,5 +965,6 @@ wxString GetExecutablePath()
 {
 	const char* system = nullptr;
 	environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system);
-	return Path::Combine(system);
+	return (system);
+	//return Path::Combine(system, "pcsx2/PCSX2");
 }

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -264,7 +264,7 @@ void retro_init(void)
 
 	// get the BIOS available and fill the option
 
-	bios_dir = Path::Combine(system, "pcsx2/bios");
+	bios_dir = Path::Combine(system);
 
 	wxArrayString bios_list;
 	wxDir::GetAllFiles(bios_dir.GetFullPath(), &bios_list, L"*.*", wxDIR_FILES);
@@ -965,5 +965,5 @@ wxString GetExecutablePath()
 {
 	const char* system = nullptr;
 	environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system);
-	return Path::Combine(system, "pcsx2/PCSX2");
+	return Path::Combine(system);
 }

--- a/libretro/main.cpp
+++ b/libretro/main.cpp
@@ -264,7 +264,7 @@ void retro_init(void)
 
 	// get the BIOS available and fill the option
 
-	bios_dir = Path::Combine(system);
+	bios_dir = (system);
 
 	wxArrayString bios_list;
 	wxDir::GetAllFiles(bios_dir.GetFullPath(), &bios_list, L"*.*", wxDIR_FILES);


### PR DESCRIPTION
With this PR users can now simply place their PS2 BIOS files in the **system** folder, rather than in system > pcsx2 > bios

This will disrupt existing setups, as the core will no longer detect BIOS files in the system > pcsx2 > bios directory, but it also brings the PCSX2 core more in-line with almost every other core simply having their BIOS files in the system folder. 

This PR is for consistency, and to simplify the RetroArch core setup process for end-users and will require changes to existing documentation. 

If anyone has a better method to check for both the system & pcsx2 > bios directory, that'd be much better! 